### PR TITLE
Fix brew support. Implement `bulkwalk`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Easy SNMP
 =========
 
-|Build Status| |Coverage Status| |License|
+|Build Status| |Coverage Status| |Gitter| |License|
 
 .. |Build Status| image:: https://travis-ci.org/fgimian/easysnmp.svg?branch=master
    :target: https://travis-ci.org/fgimian/easysnmp
@@ -9,6 +9,9 @@ Easy SNMP
    :target: https://coveralls.io/r/fgimian/easysnmp
 .. |License| image:: https://img.shields.io/badge/license-BSD-blue.svg
    :target: https://github.com/fgimian/easysnmp/blob/master/LICENSE
+.. |Gitter| image:: https://badges.gitter.im/easysnmp/Lobby.svg
+   :alt: Join the chat at https://gitter.im/easysnmp/Lobby
+   :target: https://gitter.im/easysnmp/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
 .. image:: https://raw.githubusercontent.com/fgimian/easysnmp/master/images/easysnmp-logo.png
     :alt: Easy SNMP Logo

--- a/easysnmp/__init__.py
+++ b/easysnmp/__init__.py
@@ -1,6 +1,6 @@
 from .easy import (  # noqa
     snmp_get, snmp_set, snmp_set_multiple, snmp_get_next, snmp_get_bulk,
-    snmp_walk
+    snmp_walk, snmp_bulkwalk
 )
 from .exceptions import (  # noqa
     EasySNMPError, EasySNMPConnectionError, EasySNMPTimeoutError,

--- a/easysnmp/easy.py
+++ b/easysnmp/easy.py
@@ -78,7 +78,7 @@ def snmp_get_next(oids, **session_kargs):
     return session.get_next(oids)
 
 
-def snmp_get_bulk(oids, non_repeaters, max_repetitions, **session_kargs):
+def snmp_get_bulk(oids, non_repeaters=0, max_repetitions=10, **session_kargs):
     """
     Performs a bulk SNMP GET operation to retrieve multiple pieces of
     information in a single packet.
@@ -119,3 +119,29 @@ def snmp_walk(oids='.1.3.6.1.2.1', **session_kargs):
 
     session = Session(**session_kargs)
     return session.walk(oids)
+
+
+def snmp_bulkwalk(
+    oids='.1.3.6.1.2.1', non_repeaters=0, max_repetitions=10,
+    **session_kargs
+):
+    """
+    Uses SNMP GETBULK operation using the prepared session to
+    automatically retrieve multiple pieces of information in an OID
+
+    :param oids: you may pass in a single item
+                 * string representing the
+                 entire OID (e.g. 'sysDescr.0')
+                 * tuple (name, index) (e.g. ('sysDescr', 0))
+                 * list of OIDs
+    :param non_repeaters: the number of objects that are only expected to
+                          return a single GETNEXT instance, not multiple
+                          instances
+    :param max_repetitions: the number of objects that should be returned
+                            for all the repeating OIDs
+    :return: a list of SNMPVariable objects containing the values that
+             were retrieved via SNMP
+    """
+
+    session = Session(**session_kargs)
+    return session.bulkwalk(oids, non_repeaters, max_repetitions)

--- a/easysnmp/exceptions.py
+++ b/easysnmp/exceptions.py
@@ -17,7 +17,7 @@ class EasySNMPTimeoutError(EasySNMPConnectionError):
 
 
 class EasySNMPUnknownObjectIDError(EasySNMPError):
-    """Raised when an inexisted OID is requested."""
+    """Raised when a nonexistent OID is requested."""
     pass
 
 
@@ -32,7 +32,7 @@ class EasySNMPNoSuchNameError(EasySNMPError):
 class EasySNMPNoSuchObjectError(EasySNMPError):
     """
     Raised when an OID is requested which may have some form of existence but
-    an invalid object name.
+    is an invalid object name.
     """
     pass
 
@@ -46,6 +46,6 @@ class EasySNMPNoSuchInstanceError(EasySNMPError):
 
 class EasySNMPUndeterminedTypeError(EasySNMPError):
     """
-    Raised when the type cannot be determine when setting the value of an OID.
+    Raised when the type cannot be determined when setting the value of an OID.
     """
     pass

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -3149,6 +3149,11 @@ static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
             if (status != 0)
             {
                 error = 1;
+                if (response)
+                {
+                    snmp_free_pdu(response);
+                    response = NULL;
+                }
                 goto done;
             }
 
@@ -3424,7 +3429,7 @@ static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args) {
             varlist_len++;
             Py_DECREF(varbind);
         }
-        Py_DECREF(varlist_iter);
+        Py_XDECREF(varlist_iter);
 
         oid_arr_len = calloc(varlist_len, sizeof(int));
         oid_arr = calloc(varlist_len, sizeof(oid *));

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -1,5 +1,26 @@
 #include <Python.h>
 
+/*
+ * Old versions of Python use CObject API instead of Capsules.
+ * Both are similar, so we just use a bit of preprocessor magic
+ * to provide backwards compatibility.
+ */
+#if (                                                                    \
+      ((PY_VERSION_HEX <  0x02070000) ||     \
+       (PY_VERSION_HEX >= 0x03000000) && \
+       (PY_VERSION_HEX <  0x03010000))       \
+    )
+
+    #define USE_DEPRECATED_COBJECT_API
+
+    #define PyCapsule_New(pointer, name, destructor)     \
+        (PyCObject_FromVoidPtr(pointer, destructor))
+
+    #define PyCapsule_GetPointer(capsule, name) \
+        (PyCObject_AsVoidPtr(capsule))
+
+#endif /* PY_VERSION_HEX */
+
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 #include <net-snmp/snmpv3_api.h>
@@ -31,7 +52,7 @@
  * heavily on the heap; if we need to track more, we can
  * just malloc on the heap.
  */
-#define DEFAULT_NUM_BAD_OIDS (sizeof(bitarray_word) * 8 * 3)
+#define DEFAULT_NUM_BAD_OIDS (sizeof(bitarray) * 8 * 3)
 
 #define STRLEN(x) ((x) ? strlen((x)) : 0)
 
@@ -46,6 +67,8 @@
 #define TYPE_UNKNOWN      (0)
 #define MAX_TYPE_NAME_LEN (32)
 #define STR_BUF_SIZE      ((MAX_TYPE_NAME_LEN) * (MAX_OID_LEN))
+#define MAX_VALUE_SIZE    (65536)
+#define MAX_INVALID_OIDS  (MAX_VALUE_SIZE / MIN_OID_LEN)
 #define ENG_ID_BUF_SIZE   (32)
 
 #define NO_RETRY_NOSUCH (0)
@@ -67,7 +90,49 @@
     while (0)
 
 typedef netsnmp_session SnmpSession;
-typedef struct tree SnmpMibNode;
+/*
+ * This structure is attached to the easysnmp.Session
+ * object as a Python Capsule (or CObject).
+ *
+ * This allows a one time allocation of large buffers
+ * without resorting to (unnecessary) allocation on the
+ * stack, but also remains thread safe; as long as only
+ * one Session object is restricted to each thread.
+ *
+ * This is allocated in create_session_capsule()
+ * and later (automatically via garbage collection) destroyed
+ * delete_session_capsule().
+ */
+struct session_capsule_ctx
+{
+    /*
+     * Technically this should be a (void *), but this probably
+     * won't ever change in Net-SNMP.
+     */
+    netsnmp_session *handle;
+    /* buf is reusable and stores OID values and names */
+    u_char buf[MAX_VALUE_SIZE];
+    /* err_str is used to fetch the error message from net-snmp libs */
+    char err_str[STR_BUF_SIZE];
+    /* used by netsnmp_{get,getnext,set}. */
+    oid oid_arr[MAX_OID_LEN];
+    /*
+     * invalid_oids is a bitarray for maintaining invalid OIDS when performing
+     * SNMPv1 requests.
+     *
+     * Note: prior to use, the number of bits required should be cleared.
+     */
+    unsigned char invalid_oids_buf[MAX_INVALID_OIDS / CHAR_BIT];
+    bitarray *invalid_oids;
+};
+static PyObject *create_session_capsule(SnmpSession *ss);
+static void *get_session_handle_from_capsule(PyObject *session_capsule);
+#ifdef USE_DEPRECATED_COBJECT_API
+    static void delete_session_capsule(void *session_ptr);
+#else
+    static void delete_session_capsule(PyObject *session_capsule);
+#endif
+
 static int __is_numeric_oid(char *oidstr);
 static int __is_leaf(struct tree *tp);
 static int __translate_appl_type(char *typestr);
@@ -1188,6 +1253,7 @@ retry:
                         if (*response)
                         {
                             snmp_free_pdu(*response);
+                            *response = NULL;
                         }
 
                         retry_num++;
@@ -1409,6 +1475,100 @@ static void __py_netsnmp_update_session_errors(PyObject *session,
     Py_DECREF(tmp_for_conversion);
 }
 
+/*
+ * Returns a new reference to a python capsule object containing
+ * a newly allocated session_capsule_ctx.
+ *
+ * This function will raise an exception on failure.
+ */
+static PyObject *create_session_capsule(SnmpSession *session)
+{
+    void *handle = NULL;
+    struct session_capsule_ctx *ctx = NULL;
+    PyObject *capsule = NULL;
+    /* create a long lived handle from throwaway session object */
+    if (!(handle = snmp_sess_open(session)))
+    {
+        PyErr_SetString(EasySNMPConnectionError,
+                        "couldn't create SNMP handle");
+        goto done;
+    }
+    if (!(ctx = malloc(sizeof *ctx)))
+    {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "could not malloc() session_capsule_ctx");
+        goto done;
+    }
+    /*
+     * Create a capsule containing the ctx pointer with an "anonymous" name,
+     * which is automatically destroyed by delete_session_capsule() when
+     * no more references to the object are held.
+     */
+    if (!(capsule = PyCapsule_New(ctx, NULL, delete_session_capsule)))
+    {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "failed to create Python Capsule object");
+        goto done;
+    }
+    /* init session context variables */
+    ctx->handle = handle;
+    ctx->invalid_oids = (bitarray *) ctx->invalid_oids_buf;
+    bitarray_buf_init(ctx->invalid_oids, sizeof(ctx->invalid_oids_buf));
+    return (capsule);
+done:
+    if (handle)
+    {
+        snmp_sess_close(handle);
+    }
+    if (ctx)
+    {
+        free(ctx);
+    }
+    if (capsule)
+    {
+        Py_XDECREF(capsule);
+    }
+    return NULL;
+}
+
+static void *get_session_handle_from_capsule(PyObject *session_capsule)
+{
+    if (!session_capsule)
+    {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "NULL arg calling get_session_handle_from_capsule");
+        return NULL;
+    }
+    /* raises exception on failure. */
+    return PyCapsule_GetPointer(session_capsule, NULL);
+}
+
+#ifdef USE_DEPRECATED_COBJECT_API
+/* The CObject API calls destructor with stored pointer */
+    static void delete_session_capsule(void *session_ptr)
+    {
+        struct session_capsule_ctx *ctx = session_ptr;
+        if (ctx)
+        {
+            snmp_sess_close(ctx->handle);
+            free(ctx);
+        }
+    }
+#else
+    /* Automatically called when Python reclaims session_capsule object. */
+    static void delete_session_capsule(PyObject *session_capsule)
+    {
+        /* PyCapsule_GetPointer will raise an exception if it fails. */
+        struct session_capsule_ctx *ctx = PyCapsule_GetPointer(session_capsule, NULL);
+        if (ctx)
+        {
+            snmp_sess_close(ctx->handle);
+            free(ctx);
+        }
+    }
+#endif /* USE_DEPRECATED_COBJECT_API */
+
+
 static PyObject *netsnmp_create_session(PyObject *self, PyObject *args)
 {
     int version;
@@ -1418,13 +1578,11 @@ static PyObject *netsnmp_create_session(PyObject *self, PyObject *args)
     int retries;
     int timeout;
     SnmpSession session = {0};
-    SnmpSession *ss = NULL;
-    int error = 0;
 
     if (!PyArg_ParseTuple(args, "issiii", &version, &community, &peer, &lport,
                           &retries, &timeout))
     {
-        return NULL;
+        goto done;
     }
 
     snmp_sess_init(&session);
@@ -1450,8 +1608,7 @@ static PyObject *netsnmp_create_session(PyObject *self, PyObject *args)
     {
         PyErr_Format(PyExc_ValueError, "unsupported SNMP version (%d)",
                      version);
-        error = 1;
-        goto end;
+        goto done;
     }
 
     session.community_len = STRLEN((char *)community);
@@ -1462,24 +1619,11 @@ static PyObject *netsnmp_create_session(PyObject *self, PyObject *args)
     session.timeout = timeout; /* 1000000L */
     session.authenticator = NULL;
 
-    ss = snmp_sess_open(&session);
+    return create_session_capsule(&session);
 
-    if (ss == NULL)
-    {
-        PyErr_SetString(EasySNMPConnectionError, "couldn't open SNMP session");
-        error = 1;
-    }
+done:
+    return NULL;
 
-end:
-
-    if (error)
-    {
-        return NULL;
-    }
-    else
-    {
-        return PyLong_FromVoidPtr((void *)ss);
-    }
 }
 
 static PyObject *netsnmp_create_session_v3(PyObject *self, PyObject *args)
@@ -1501,8 +1645,6 @@ static PyObject *netsnmp_create_session_v3(PyObject *self, PyObject *args)
     int eng_boots;
     int eng_time;
     SnmpSession session = {0};
-    SnmpSession *ss = NULL;
-    int error = 0;
 
     if (!PyArg_ParseTuple(args, "isiiisisssssssii", &version,
                           &peer, &lport, &retries, &timeout,
@@ -1525,8 +1667,7 @@ static PyObject *netsnmp_create_session_v3(PyObject *self, PyObject *args)
     {
         PyErr_Format(PyExc_ValueError, "unsupported SNMP version (%d)",
                      version);
-        error = 1;
-        goto end;
+        goto done;
     }
 
     session.peername = peer;
@@ -1575,8 +1716,7 @@ static PyObject *netsnmp_create_session_v3(PyObject *self, PyObject *args)
     {
         PyErr_Format(PyExc_ValueError,
                      "unsupported authentication protocol (%s)", auth_proto);
-        error = 1;
-        goto end;
+        goto done;
     }
     if (session.securityLevel >= SNMP_SEC_LEVEL_AUTHNOPRIV)
     {
@@ -1592,8 +1732,7 @@ static PyObject *netsnmp_create_session_v3(PyObject *self, PyObject *args)
                 PyErr_SetString(EasySNMPConnectionError,
                                 "error generating Ku from authentication "
                                 "password");
-                error = 1;
-                goto end;
+                goto done;
             }
         }
     }
@@ -1624,8 +1763,7 @@ static PyObject *netsnmp_create_session_v3(PyObject *self, PyObject *args)
     {
         PyErr_Format(PyExc_ValueError,
                      "unsupported privacy protocol (%s)", priv_proto);
-        error = 1;
-        goto end;
+        goto done;
     }
 
     if (session.securityLevel >= SNMP_SEC_LEVEL_AUTHPRIV)
@@ -1639,33 +1777,17 @@ static PyObject *netsnmp_create_session_v3(PyObject *self, PyObject *args)
         {
             PyErr_SetString(EasySNMPConnectionError,
                             "couldn't gen Ku from priv pass phrase");
-            goto end;
+            goto done;
         }
     }
+    return create_session_capsule(&session);
 
-    ss = snmp_sess_open(&session);
+done:
+    SAFE_FREE(session.securityEngineID);
+    SAFE_FREE(session.contextEngineID);
 
-    if (ss == NULL)
-    {
-        PyErr_Format(EasySNMPConnectionError,
-                     "couldn't open SNMP session (%s)",
-                     snmp_api_errstring(snmp_errno));
-        error = 1;
-    }
+    return NULL;
 
-end:
-
-    free(session.securityEngineID);
-    free(session.contextEngineID);
-
-    if (error)
-    {
-        return NULL;
-    }
-    else
-    {
-        return PyLong_FromVoidPtr((void *)ss);
-    }
 }
 
 static PyObject *netsnmp_create_session_tunneled(PyObject *self,
@@ -1685,8 +1807,6 @@ static PyObject *netsnmp_create_session_tunneled(PyObject *self,
     char *their_hostname;
     char *trust_cert;
     SnmpSession session = {0};
-    SnmpSession *ss = NULL;
-    int error = 0;
 
     if (!PyArg_ParseTuple(args, "isiiisissssss", &version,
                           &peer, &lport, &retries, &timeout,
@@ -1695,7 +1815,7 @@ static PyObject *netsnmp_create_session_tunneled(PyObject *self,
                           &our_identity, &their_identity,
                           &their_hostname, &trust_cert))
     {
-        return NULL;
+        goto done;
     }
 
     if (version != 3)
@@ -1703,7 +1823,7 @@ static PyObject *netsnmp_create_session_tunneled(PyObject *self,
         PyErr_SetString(PyExc_ValueError,
                         "you must use SNMP version 3 as it's the only "
                         "version that supports tunneling");
-        return NULL;
+        goto done;
     }
 
     snmp_sess_init(&session);
@@ -1728,7 +1848,7 @@ static PyObject *netsnmp_create_session_tunneled(PyObject *self,
         {
             py_log_msg(ERROR, "failed to initialize the transport "
                               "configuration container");
-            return NULL;
+            goto done;
         }
 
         session.transport_configuration->compare =
@@ -1754,68 +1874,44 @@ static PyObject *netsnmp_create_session_tunneled(PyObject *self,
         CONTAINER_INSERT(session.transport_configuration,
                          netsnmp_transport_create_config("trust_cert",
                                                          trust_cert));
+    return create_session_capsule(&session);
 
-    ss = snmp_sess_open(&session);
+done:
+    return NULL;
 
-    if (!ss)
-    {
-        return NULL;
-    }
-
-    /*
-     * Note: on a 64-bit system the statement below discards the upper 32
-     * bits of "ss", which is most likely a bug.
-     */
-    if (error)
-    {
-        return NULL;
-    }
-    else
-    {
-        return Py_BuildValue("i", (int)(uintptr_t)ss);
-    }
-}
-
-static PyObject *netsnmp_delete_session(PyObject *self, PyObject *args)
-{
-    PyObject *session;
-    SnmpSession *ss = NULL;
-
-    if (!PyArg_ParseTuple(args, "O", &session))
-    {
-        return NULL;
-    }
-
-    ss = (SnmpSession *)py_netsnmp_attr_void_ptr(session, "sess_ptr");
-
-    snmp_sess_close(ss);
-    return (Py_BuildValue(""));
 }
 
 static PyObject *netsnmp_get(PyObject *self, PyObject *args)
 {
-    PyObject *session;
-    PyObject *varlist;
-    PyObject *varbind;
+    PyObject *session = NULL;
+    PyObject *varlist = NULL;
+    PyObject *varbind = NULL;
+    PyObject *varlist_iter = NULL;
     int varlist_len = 0;
     int varlist_ind;
-    netsnmp_session *ss;
-    netsnmp_pdu *pdu, *response;
-    netsnmp_variable_list *vars;
-    struct tree *tp;
+
+    /* variables associated for session_ctx (can be condensed into a macro) */
+    PyObject *sess_ptr = NULL;
+    struct session_capsule_ctx *session_ctx = NULL;
+    netsnmp_session *ss = NULL;
+    oid *oid_arr = NULL;
+    int oid_arr_len = 0;
+    u_char *str_buf = NULL;
+    u_char *str_bufp = NULL;
+    char *err_str = NULL;
+    bitarray *invalid_oids = NULL;
+
+    netsnmp_pdu *pdu = NULL;
+    netsnmp_pdu *response = NULL;
+    netsnmp_variable_list *vars = NULL;
+    struct tree *tp = NULL;
     int len;
-    oid *oid_arr;
-    int oid_arr_len = MAX_OID_LEN;
     int type;
     char type_str[MAX_TYPE_NAME_LEN];
     int status;
-    u_char str_buf[STR_BUF_SIZE];
-    u_char *str_bufp = str_buf;
-    size_t str_buf_len = sizeof(str_buf);
-    size_t out_len = 0;
     int buf_over = 0;
-    char *tag;
-    char *iid;
+    char *tag = NULL;
+    char *iid = NULL;
     int getlabel_flag = NO_FLAGS;
     int sprintval_flag = USE_BASIC;
     int old_format;
@@ -1823,313 +1919,325 @@ static PyObject *netsnmp_get(PyObject *self, PyObject *args)
     int retry_nosuch;
     int err_ind;
     int err_num;
-    char err_str[STR_BUF_SIZE];
-    char *tmpstr;
+    char *tmpstr = NULL;
     Py_ssize_t tmplen;
     int error = 0;
     unsigned long snmp_version = 0;
 
-    BITARRAY_DECLARE(snmpv1_invalid_oids, DEFAULT_NUM_BAD_OIDS);
-    bitarray *invalid_oids = snmpv1_invalid_oids;
-
-    oid_arr = calloc(MAX_OID_LEN, sizeof(oid));
-
-    if (oid_arr && args)
+    if (!args)
     {
-        if (!PyArg_ParseTuple(args, "OO", &session, &varlist))
+        const char *err_msg = "netsnmp_get: missing arguments";
+        PyErr_SetString(PyExc_ValueError, err_msg);
+        error = 1;
+        goto done;
+    }
+
+    if (!PyArg_ParseTuple(args, "OO", &session, &varlist))
+    {
+        goto done;
+    }
+
+    sess_ptr = PyObject_GetAttrString(session, "sess_ptr");
+    session_ctx = get_session_handle_from_capsule(sess_ptr);
+
+    if (!session_ctx)
+    {
+        goto done;
+    }
+
+    ss = session_ctx->handle;
+    invalid_oids = session_ctx->invalid_oids;
+    oid_arr = session_ctx->oid_arr;
+    str_buf = session_ctx->buf;
+    str_bufp = str_buf;
+    err_str = session_ctx->err_str;
+
+    snmp_version = py_netsnmp_attr_long(session, "version");
+
+    if (py_netsnmp_attr_string(session, "error_string", &tmpstr, &tmplen) < 0)
+    {
+        goto done;
+    }
+
+    if (py_netsnmp_attr_long(session, "use_long_names"))
+    {
+        getlabel_flag |= USE_LONG_NAMES;
+    }
+    if (py_netsnmp_attr_long(session, "use_numeric"))
+    {
+        getlabel_flag |= USE_NUMERIC_OIDS;
+    }
+    if (py_netsnmp_attr_long(session, "use_enums"))
+    {
+        sprintval_flag = USE_ENUMS;
+    }
+    if (py_netsnmp_attr_long(session, "use_sprint_value"))
+    {
+        sprintval_flag = USE_SPRINT_VALUE;
+    }
+    best_guess = py_netsnmp_attr_long(session, "best_guess");
+    retry_nosuch = py_netsnmp_attr_long(session, "retry_no_such");
+
+    pdu = snmp_pdu_create(SNMP_MSG_GET);
+
+    if (!varlist)
+    {
+        const char *err_msg = "unexpected error: varlist == null";
+        PyErr_SetString(PyExc_RuntimeError, err_msg);
+        error = 1;
+        goto done;
+    }
+
+    varlist_iter = PyObject_GetIter(varlist);
+
+    while (varlist_iter && (varbind = PyIter_Next(varlist_iter)))
+    {
+        if (py_netsnmp_attr_string(varbind, "oid", &tag, NULL) < 0 ||
+            py_netsnmp_attr_string(varbind, "oid_index", &iid, NULL) < 0)
         {
-            goto done;
+            oid_arr_len = 0;
+        }
+        else
+        {
+            tp = __tag2oid(tag, iid, oid_arr, &oid_arr_len, NULL,
+                           best_guess);
         }
 
-        ss = (SnmpSession *)py_netsnmp_attr_void_ptr(session, "sess_ptr");
-
-        snmp_version = py_netsnmp_attr_long(session, "version");
-
-        if (py_netsnmp_attr_string(session, "error_string", &tmpstr, &tmplen) < 0)
+        if (oid_arr_len)
         {
-            goto done;
+            snmp_add_null_var(pdu, oid_arr, oid_arr_len);
+            varlist_len++;
         }
-
-        if (py_netsnmp_attr_long(session, "use_long_names"))
+        else
         {
-            getlabel_flag |= USE_LONG_NAMES;
-        }
-        if (py_netsnmp_attr_long(session, "use_numeric"))
-        {
-            getlabel_flag |= USE_NUMERIC_OIDS;
-        }
-        if (py_netsnmp_attr_long(session, "use_enums"))
-        {
-            sprintval_flag = USE_ENUMS;
-        }
-        if (py_netsnmp_attr_long(session, "use_sprint_value"))
-        {
-            sprintval_flag = USE_SPRINT_VALUE;
-        }
-        best_guess = py_netsnmp_attr_long(session, "best_guess");
-        retry_nosuch = py_netsnmp_attr_long(session, "retry_no_such");
-
-        pdu = snmp_pdu_create(SNMP_MSG_GET);
-
-        if (varlist)
-        {
-            PyObject *varlist_iter = PyObject_GetIter(varlist);
-
-            while (varlist_iter && (varbind = PyIter_Next(varlist_iter)))
-            {
-                if (py_netsnmp_attr_string(varbind, "oid", &tag, NULL) < 0 ||
-                    py_netsnmp_attr_string(varbind, "oid_index", &iid, NULL) < 0)
-                {
-                    oid_arr_len = 0;
-                }
-                else
-                {
-                    tp = __tag2oid(tag, iid, oid_arr, &oid_arr_len, NULL,
-                                   best_guess);
-                }
-
-                if (oid_arr_len)
-                {
-                    snmp_add_null_var(pdu, oid_arr, oid_arr_len);
-                    varlist_len++;
-                }
-                else
-                {
-                    PyErr_Format(EasySNMPUnknownObjectIDError,
-                                 "unknown object id (%s)",
-                                 (tag ? tag : "<null>"));
-                    error = 1;
-                    snmp_free_pdu(pdu);
-                    Py_DECREF(varbind);
-                    goto done;
-                }
-                /* release reference when done */
-                Py_DECREF(varbind);
-            }
-
-            Py_DECREF(varlist_iter);
-
-            if (PyErr_Occurred())
-            {
-                error = 1;
-                snmp_free_pdu(pdu);
-                goto done;
-            }
-        }
-
-        /* if we cannot represent the number of bad oids, we will need to resize. */
-        if (snmp_version == 1 && DEFAULT_NUM_BAD_OIDS < varlist_len)
-        {
-            invalid_oids = bitarray_calloc(varlist_len);
-
-            if (!invalid_oids)
-            {
-                error = 1;
-                snmp_free_pdu(pdu);
-                const char *err_msg = "failed to call bitarray_calloc";
-                PyErr_SetString(PyExc_RuntimeError, err_msg);
-                goto done;
-            }
-        }
-
-        status = __send_sync_pdu(ss, pdu, &response, retry_nosuch, err_str,
-                                 &err_num, &err_ind, invalid_oids);
-
-        __py_netsnmp_update_session_errors(session, err_str, err_num, err_ind);
-        if (status != 0)
-        {
+            PyErr_Format(EasySNMPUnknownObjectIDError,
+                         "unknown object id (%s)",
+                         (tag ? tag : "<null>"));
             error = 1;
+            snmp_free_pdu(pdu);
+            Py_DECREF(varbind);
+            Py_DECREF(varlist_iter);
             goto done;
         }
 
-        /*
-        ** Set up for numeric or full OID's, if necessary.  Save the old
-        ** output format so that it can be restored when we finish -- this
-        ** is a library-wide global, and has to be set/restored for each
-        ** session.
-        */
-        old_format = netsnmp_ds_get_int(NETSNMP_DS_LIBRARY_ID,
-                                        NETSNMP_DS_LIB_OID_OUTPUT_FORMAT);
+        /* release reference when done */
+        Py_DECREF(varbind);
+    }
 
-        if (py_netsnmp_attr_long(session, "use_long_names"))
+    Py_DECREF(varlist_iter);
+
+    if (PyErr_Occurred())
+    {
+        error = 1;
+        snmp_free_pdu(pdu);
+        goto done;
+    }
+
+    if (snmp_version == 1)
+    {
+        bitarray_clear_bits(invalid_oids, (size_t) varlist_len);
+    }
+
+    status = __send_sync_pdu(ss, pdu, &response, retry_nosuch, err_str,
+                             &err_num, &err_ind, invalid_oids);
+
+    __py_netsnmp_update_session_errors(session, err_str, err_num, err_ind);
+    if (status != 0)
+    {
+        error = 1;
+        goto done;
+    }
+
+    /*
+     * Set up for numeric or full OID's, if necessary.  Save the old
+     * output format so that it can be restored when we finish -- this
+     * is a library-wide global, and has to be set/restored for each
+     * session.
+     */
+    old_format = netsnmp_ds_get_int(NETSNMP_DS_LIBRARY_ID,
+                                    NETSNMP_DS_LIB_OID_OUTPUT_FORMAT);
+
+    if (py_netsnmp_attr_long(session, "use_long_names"))
+    {
+        getlabel_flag |= USE_LONG_NAMES;
+
+        netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
+                           NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
+                           NETSNMP_OID_OUTPUT_FULL);
+    }
+    /*
+     * Setting use_numeric forces use_long_names on so check for
+     * use_numeric after use_long_names (above) to make sure the final
+     * outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
+     * NETSNMP_OID_OUTPUT_NUMERIC
+     */
+    if (py_netsnmp_attr_long(session, "use_numeric"))
+    {
+        getlabel_flag |= USE_LONG_NAMES;
+        getlabel_flag |= USE_NUMERIC_OIDS;
+
+        netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
+                           NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
+                           NETSNMP_OID_OUTPUT_NUMERIC);
+    }
+
+
+    /*
+     * In SNMPv1 we go through the response variables only if we know
+     * the varlist_ind is not set in the invalid_oids bit array.
+     * For bits that are set, we fix the input varbind so that it
+     * indicates NOSUCHNAME. For bits that are not set, we fill in the
+     * corresponding varbind and advance.
+     *
+     * In SNMPv2/v3 we simply fill the response variables against the
+     * original input Varbind list.
+     */
+    vars = (response ? response->variables : NULL);
+
+    for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
+    {
+        int no_such_name = 0;
+
+        if (snmp_version == 1)
         {
-            getlabel_flag |= USE_LONG_NAMES;
-
-            netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
-                               NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
-                               NETSNMP_OID_OUTPUT_FULL);
+            if (!vars)
+            {
+                /* if no more variables in response then remaining varbinds are invalid. */
+                no_such_name = 1;
+            }
+            else if (bitarray_test_bit(invalid_oids, varlist_ind))
+            {
+                /* oid is invalid */
+                no_such_name = 1;
+            }
         }
-        /*
-         * Setting use_numeric forces use_long_names on so check for
-         * use_numeric after use_long_names (above) to make sure the final
-         * outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
-         * NETSNMP_OID_OUTPUT_NUMERIC
-         */
-        if (py_netsnmp_attr_long(session, "use_numeric"))
+        else if (!vars)
         {
-            getlabel_flag |= USE_LONG_NAMES;
-            getlabel_flag |= USE_NUMERIC_OIDS;
-
-            netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
-                               NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
-                               NETSNMP_OID_OUTPUT_NUMERIC);
+            /*
+             * sanity check for snmp v2/v3: no more varbinds to inspect;
+             * this should throw an exception.
+             */
+            py_log_msg(DEBUG,
+                       "netsnmp_get: response had less vars compared to varlist");
+            break;
         }
 
-        /*
-         * In SNMPv1 we go through the response variables only if we know
-         * the varlist_ind is not set in the invalid_oids bit array.
-         * For bits that are set, we fix the input varbind so that it
-         * indicates NOSUCHNAME. For bits that are not set, we fill in the
-         * corresponding varbind and advance.
-         *
-         * In SNMPv2/v3 we simply fill the response variables against the
-         * original input Varbind list.
-         */
-        vars = (response ? response->variables : NULL);
+        varbind = PySequence_GetItem(varlist, varlist_ind);
 
-        for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
+        if (no_such_name)
         {
-            int no_such_name = 0;
-
-            if (snmp_version == 1)
-            {
-                /* check if oid is invalid */
-                if (bitarray_test_bit(invalid_oids, varlist_ind))
-                {
-                    no_such_name = 1;
-                }
-            }
-            else if (!vars)
-            {
-                /*
-                 * no more varbinds to inspect
-                 * (this will only happen if no response is received from SNMP.
-                 */
-                break;
-            }
-
-            varbind = PySequence_GetItem(varlist, varlist_ind);
-
-            if (!no_such_name && PyObject_HasAttrString(varbind, "oid"))
-            {
-                *str_buf = '.';
-                *(str_buf + 1) = '\0';
-                out_len = 0;
-                tp = netsnmp_sprint_realloc_objid_tree(&str_bufp, &str_buf_len,
-                                                       &out_len, 0, &buf_over,
-                                                       vars->name,
-                                                       vars->name_length);
-
-                py_log_msg(DEBUG, "netsnmp_get: str_bufp: %s:%d:%d",
-                           str_bufp, (int) str_buf_len, (int) out_len);
-
-                str_buf[sizeof(str_buf) - 1] = '\0';
-
-                type = __translate_asn_type(vars->type);
-
-                if (__is_leaf(tp))
-                {
-                    getlabel_flag &= ~NON_LEAF_NAME;
-                    py_log_msg(DEBUG, "netsnmp_get: is_leaf: %d", tp->type);
-                }
-                else
-                {
-                    getlabel_flag |= NON_LEAF_NAME;
-                    py_log_msg(DEBUG, "netsnmp_get: !is_leaf: %d", tp->type);
-                }
-
-                py_log_msg(DEBUG, "netsnmp_get: str_buf: %s", str_buf);
-
-                __get_label_iid((char *) str_buf, &tag, &iid, getlabel_flag);
-
-                py_netsnmp_attr_set_string(varbind, "oid", tag, STRLEN(tag));
-                py_netsnmp_attr_set_string(varbind, "oid_index", iid,
-                                           STRLEN(iid));
-
-                __get_type_str(type, type_str, 1);
-
-                py_netsnmp_attr_set_string(varbind, "snmp_type", type_str,
-                                           strlen(type_str));
-
-                len = __snprint_value((char *) str_buf, sizeof(str_buf),
-                                      vars, tp, type, sprintval_flag);
-                str_buf[len] = '\0';
-                py_netsnmp_attr_set_string(varbind, "value",
-                                           (char *) str_buf, len);
-
-                Py_DECREF(varbind);
-            }
-            else if (no_such_name)
-            {
-                if (!PyObject_HasAttrString(varbind, "oid"))
-                {
-                    py_log_msg(DEBUG, "netsnmp_get: bad varbind (%d)",
-                               varlist_ind);
-                    Py_XDECREF(varbind);
-                }
-
-                py_netsnmp_attr_set_string(varbind, "snmp_type", "NOSUCHNAME",
-                                           strlen("NOSUCHNAME"));
-
-                py_netsnmp_attr_set_string(varbind, "value",
-                                           "NOSUCHNAME", strlen("NOSUCHNAME"));
-
-                Py_DECREF(varbind);
-            }
-            else
+            if (!PyObject_HasAttrString(varbind, "oid"))
             {
                 py_log_msg(DEBUG, "netsnmp_get: bad varbind (%d)",
                            varlist_ind);
                 Py_XDECREF(varbind);
             }
 
-            /*
-             * in v1 this will only advance if the varbind index is valid;
-             * in v2/v3 no_such_name is always set to 0.
-             */
-            if (!no_such_name)
-            {
-                vars = vars->next_variable;
-            }
+            py_netsnmp_attr_set_string(varbind, "snmp_type", "NOSUCHNAME",
+                                       strlen("NOSUCHNAME"));
+
+            py_netsnmp_attr_set_string(varbind, "value",
+                                       "NOSUCHNAME", strlen("NOSUCHNAME"));
+
+            Py_DECREF(varbind);
         }
-
-        /* Reset the library's behavior for numeric/symbolic OID's. */
-        netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
-                           NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
-                           old_format);
-
-        if (response)
+        else if (PyObject_HasAttrString(varbind, "oid"))
         {
-            snmp_free_pdu(response);
+            size_t str_buf_len = sizeof(session_ctx->buf);
+            size_t out_len = 0;
+
+            *str_buf = '.';
+            *(str_buf + 1) = '\0';
+            out_len = 0;
+            tp = netsnmp_sprint_realloc_objid_tree(&str_bufp, &str_buf_len,
+                                                   &out_len, 0, &buf_over,
+                                                   vars->name,
+                                                   vars->name_length);
+
+            py_log_msg(DEBUG, "netsnmp_get: str_bufp: %s:%lu:%lu",
+                       str_bufp, str_buf_len, out_len);
+
+            /* clamp value */
+            str_buf[sizeof(session_ctx->buf) - 1] = '\0';
+
+            type = __translate_asn_type(vars->type);
+
+            if (__is_leaf(tp))
+            {
+                getlabel_flag &= ~NON_LEAF_NAME;
+                py_log_msg(DEBUG, "netsnmp_get: is_leaf: %d", tp->type);
+            }
+            else
+            {
+                getlabel_flag |= NON_LEAF_NAME;
+                py_log_msg(DEBUG, "netsnmp_get: !is_leaf: %d", tp->type);
+            }
+
+            py_log_msg(DEBUG, "netsnmp_get: str_buf: %s", str_buf);
+
+            __get_label_iid((char *) str_buf, &tag, &iid, getlabel_flag);
+
+            py_netsnmp_attr_set_string(varbind, "oid", tag, STRLEN(tag));
+            py_netsnmp_attr_set_string(varbind, "oid_index", iid,
+                                       STRLEN(iid));
+
+            __get_type_str(type, type_str, 1);
+
+            py_netsnmp_attr_set_string(varbind, "snmp_type", type_str,
+                                       strlen(type_str));
+
+            len = __snprint_value((char *) str_buf, sizeof(session_ctx->buf),
+                                  vars, tp, type, sprintval_flag);
+            str_buf[len] = '\0';
+            py_netsnmp_attr_set_string(varbind, "value",
+                                       (char *) str_buf, len);
+
+            Py_DECREF(varbind);
         }
+        else
+        {
+            py_log_msg(DEBUG, "netsnmp_get: bad varbind (%d)", varlist_ind);
+            Py_XDECREF(varbind);
+        }
+
+        /*
+         * in v1 this will only advance if the varbind index is valid;
+         * in v2/v3 no_such_name is always set to 0.
+         */
+        if (!no_such_name)
+        {
+            vars = vars->next_variable;
+        }
+    }
+
+    /* Reset the library's behavior for numeric/symbolic OID's. */
+    netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
+                       NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
+                       old_format);
+
+    if (response)
+    {
+        snmp_free_pdu(response);
     }
 
 done:
 
-    /* the pointers will be equal if we didn't allocate additional space */
-    if (invalid_oids != snmpv1_invalid_oids)
-    {
-        bitarray_free(invalid_oids);
-    }
-
-    SAFE_FREE(oid_arr);
     if (error)
     {
         return NULL;
     }
-    else
-    {
-        return Py_None;
-    }
+    return Py_None;
 }
 
 static PyObject *netsnmp_getnext(PyObject *self, PyObject *args)
 {
-    PyObject *session;
+    PyObject *session = NULL;
+    PyObject *sess_ptr = NULL;
     PyObject *varlist;
     PyObject *varbind;
     int varlist_len = 0;
     int varlist_ind;
+    struct session_capsule_ctx *session_ctx = NULL;
     netsnmp_session *ss;
     netsnmp_pdu *pdu, *response;
     netsnmp_variable_list *vars;
@@ -2172,7 +2280,15 @@ static PyObject *netsnmp_getnext(PyObject *self, PyObject *args)
             goto done;
         }
 
-        ss = (SnmpSession *)py_netsnmp_attr_void_ptr(session, "sess_ptr");
+        sess_ptr = PyObject_GetAttrString(session, "sess_ptr");
+        session_ctx = get_session_handle_from_capsule(sess_ptr);
+
+        if (!session_ctx)
+        {
+            goto done;
+        }
+
+        ss = session_ctx->handle;
 
         snmp_version = py_netsnmp_attr_long(session, "version");
 
@@ -2453,30 +2569,29 @@ done:
     {
         return NULL;
     }
-    else
-    {
-        return Py_None;
-    }
+    return Py_None;
 }
 
 static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
 {
-    PyObject *session;
-    PyObject *varlist;
+    PyObject *session = NULL;
+    PyObject *sess_ptr = NULL;
+    PyObject *varlist = NULL;
     PyObject *varlist_iter;
     PyObject *varbind;
     PyObject *varbinds  = NULL;
     int varlist_len = 0;
     int varlist_ind;
+    struct session_capsule_ctx *session_ctx = NULL;
     netsnmp_session *ss;
-    netsnmp_pdu *pdu, *response;
-    netsnmp_pdu *newpdu;
+    netsnmp_pdu *pdu = NULL;
+    netsnmp_pdu *response = NULL;
     /*
-    Variable `oldvars` does not appear to fufill any immediate purpose and
-    causes segfaults in some cases, especially when running against OID '.1'
-    For legacy reasons, however, we will only leave it commented out, should
-    we find that it was only partially implemented or actually served a purpose
-    somewhere in the Net-SNMP library
+    ** Variable `oldvars` does not appear to fufill any immediate purpose and
+    ** causes segfaults in some cases, especially when running against OID '.1'
+    ** For legacy reasons, however, we will only leave it commented out, should
+    ** we find that it was only partially implemented or actually served a purpose
+    ** somewhere in the Net-SNMP library
     */
     netsnmp_variable_list *vars;//, *oldvars;
     struct tree *tp;
@@ -2524,7 +2639,15 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
         {
             goto done;
         }
-        ss = (SnmpSession *)py_netsnmp_attr_void_ptr(session, "sess_ptr");
+        sess_ptr = PyObject_GetAttrString(session, "sess_ptr");
+        session_ctx = get_session_handle_from_capsule(sess_ptr);
+
+        if (!session_ctx)
+        {
+            goto done;
+        }
+
+        ss = session_ctx->handle;
 
         if (py_netsnmp_attr_string(session, "error_string", &tmpstr, &tmplen) < 0)
         {
@@ -2561,6 +2684,7 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
         while (varlist_iter && (varbind = PyIter_Next(varlist_iter)))
         {
             varlist_len++;
+            Py_DECREF(varbind);
         }
         Py_DECREF(varlist_iter);
 
@@ -2612,6 +2736,7 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
                              (tag ? tag : "<null>"));
                 error = 1;
                 snmp_free_pdu(pdu);
+                pdu = NULL;
                 Py_DECREF(varbind);
                 goto done;
             }
@@ -2629,13 +2754,7 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
         {
             error = 1;
             snmp_free_pdu(pdu);
-            goto done;
-        }
-
-        if (PyErr_Occurred())
-        {
-            error = 1;
-            snmp_free_pdu(pdu);
+            pdu = NULL;
             goto done;
         }
 
@@ -2657,10 +2776,12 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
                                NETSNMP_OID_OUTPUT_FULL);
         }
 
-        /* Setting use_numeric forces use_long_names on so check for
-           use_numeric after use_long_names (above) to make sure the final
-           outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
-           NETSNMP_OID_OUTPUT_NUMERIC */
+        /*
+        ** Setting use_numeric forces use_long_names on so check for
+        ** use_numeric after use_long_names (above) to make sure the final
+        ** outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
+        ** NETSNMP_OID_OUTPUT_NUMERIC
+        */
         if (py_netsnmp_attr_long(session, "use_numeric"))
         {
             getlabel_flag |= USE_LONG_NAMES;
@@ -2678,6 +2799,7 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
         {
             error = 1;
             snmp_free_pdu(pdu);
+            pdu = NULL;
             goto done;
         }
 
@@ -2687,8 +2809,6 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
              vars != NULL;
              vars = vars->next_variable, varlist_ind++)
         {
-            oid_arr_broken_check[varlist_ind] =
-                calloc(MAX_OID_LEN, sizeof(oid));
 
             oid_arr_broken_check_len[varlist_ind] = vars->name_length;
             memcpy(oid_arr_broken_check[varlist_ind],
@@ -2703,6 +2823,12 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
             if (status != 0)
             {
                 error = 1;
+                /*
+                 * pdu is released in __send_sync_pdu if an error occurs during
+                 * the snmp_sess_synch_response function. It does not, however,
+                 * appear to be set to NULL afterwards.
+                 */
+                pdu = NULL;
                 goto done;
             }
 
@@ -2714,14 +2840,13 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
             }
             else
             {
-                newpdu = snmp_pdu_create(SNMP_MSG_GETNEXT);
+
+                pdu = snmp_pdu_create(SNMP_MSG_GETNEXT);
 
                 for (vars = (response ? response->variables : NULL),
-                     varlist_ind = 0; //,
-                     //oldvars = (pdu ? pdu->variables : NULL);
+                     varlist_ind = 0;
                      vars && (varlist_ind < varlist_len);
-                     vars = vars->next_variable, varlist_ind++)//,
-                     //oldvars = (oldvars ? oldvars->next_variable : NULL))
+                     vars = vars->next_variable, varlist_ind++)
                 {
                     if ((vars->name_length < oid_arr_len[varlist_ind]) ||
                         (memcmp(oid_arr[varlist_ind], vars->name,
@@ -2743,10 +2868,11 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
                                          oid_arr_broken_check[varlist_ind],
                                          oid_arr_broken_check_len[varlist_ind]) <= 0)
                     {
-                        /* The agent responded with an illegal response
-                           as the returning OID was lexogragically less
+                        /*
+                           The agent responded with an illegal response
+                           as the returning OID was lexograghically less
                            then or equal to the requested OID...
-                           We need to give up here because an infite
+                           We need to give up here because an infinite
                            loop will result otherwise.
 
                            XXX: this really should be an option to
@@ -2826,17 +2952,18 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
                            sizeof(oid) * vars->name_length);
                     oid_arr_broken_check_len[varlist_ind] = vars->name_length;
 
-                    snmp_add_null_var(newpdu, vars->name, vars->name_length);
+                    snmp_add_null_var(pdu, vars->name, vars->name_length);
                 }
-                pdu = newpdu;
+
             }
             if (response)
             {
                 snmp_free_pdu(response);
+                response = NULL;
             }
         }
 
-        /* Reset the library's behavior for numeric/symbolic OID's. */
+        /* Reset the library's behavior for numeric/symbolic OIDs. */
         netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
                            NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
                            old_format);
@@ -2860,26 +2987,30 @@ done:
     }
     SAFE_FREE(oid_arr);
     SAFE_FREE(oid_arr_broken_check);
+    if (pdu)
+    {
+        snmp_free_pdu(pdu);
+        pdu = NULL;
+    }
     if (error)
     {
         return NULL;
     }
-    else
-    {
-        return Py_None;
-    }
+    return Py_None;
 }
 
 static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
 {
     int nonrepeaters;
     int maxrepetitions;
-    PyObject *session;
+    PyObject *session = NULL;
+    PyObject *sess_ptr = NULL;
     PyObject *varlist;
     PyObject *varbinds;
     PyObject *varbind;
     PyObject *varbinds_iter;
     int varbind_ind;
+    struct session_capsule_ctx *session_ctx = NULL;
     netsnmp_session *ss;
     netsnmp_pdu *pdu, *response;
     netsnmp_variable_list *vars;
@@ -2922,7 +3053,15 @@ static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
         if (varlist &&
             (varbinds = PyObject_GetAttrString(varlist, "varbinds")))
         {
-            ss = (SnmpSession *)py_netsnmp_attr_void_ptr(session, "sess_ptr");
+            sess_ptr = PyObject_GetAttrString(session, "sess_ptr");
+            session_ctx = get_session_handle_from_capsule(sess_ptr);
+
+            if (!session_ctx)
+            {
+                goto done;
+            }
+
+            ss = session_ctx->handle;
 
             if (py_netsnmp_attr_string(session, "error_string", &tmpstr, &tmplen) < 0)
             {
@@ -2953,8 +3092,8 @@ static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
 
             pdu = snmp_pdu_create(SNMP_MSG_GETBULK);
 
-            pdu->non_repeaters = nonrepeaters;
-            pdu->max_repetitions = maxrepetitions;
+            pdu->errstat = nonrepeaters;
+            pdu->errindex = maxrepetitions;
 
             varbinds_iter = PyObject_GetIter(varbinds);
 
@@ -3009,11 +3148,11 @@ static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
             }
 
             /*
-            ** Set up for numeric or full OID's, if necessary.  Save the old
-            ** output format so that it can be restored when we finish -- this
-            ** is a library-wide global, and has to be set/restored for each
-            ** session.
-            */
+             * Set up for numeric or full OID's, if necessary.  Save the old
+             * output format so that it can be restored when we finish -- this
+             * is a library-wide global, and has to be set/restored for each
+             * session.
+             */
             old_format = netsnmp_ds_get_int(NETSNMP_DS_LIBRARY_ID,
                                             NETSNMP_DS_LIB_OID_OUTPUT_FORMAT);
 
@@ -3025,10 +3164,12 @@ static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
                                    NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
                                    NETSNMP_OID_OUTPUT_FULL);
             }
-            /* Setting use_numeric forces use_long_names on so check for
-               use_numeric after use_long_names (above) to make sure the final
-               outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
-               NETSNMP_OID_OUTPUT_NUMERIC */
+            /*
+             * Setting use_numeric forces use_long_names on so check for
+             * use_numeric after use_long_names (above) to make sure the final
+             * outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
+             *  NETSNMP_OID_OUTPUT_NUMERIC
+             */
             if (py_netsnmp_attr_long(session, "use_numeric"))
             {
                 getlabel_flag |= USE_LONG_NAMES;
@@ -3118,7 +3259,7 @@ static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
                     else
                     {
                         PyObject *none = Py_BuildValue(""); /* new ref */
-                        /* not sure why making vabind failed - should not happen*/
+                        /* not sure why making vabind failed - should not happen */
                         PyList_Append(varbinds, none); /* increments ref */
                         /* Return None for this variable. */
                         Py_XDECREF(varbind);
@@ -3152,32 +3293,32 @@ done:
     {
         return NULL;
     }
-    else
-    {
-        return Py_None;
-    }
+    return Py_None;
 }
 
-static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args)
-{
-    int nonrepeaters;
-    int maxrepetitions;
-    PyObject *session;
-    PyObject *varlist;
-    PyObject *varlist_iter;
-    PyObject *varbind;
-    PyObject *varbinds  = NULL;
+static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args) {
+    PyObject *session = NULL;
+    PyObject *sess_ptr = NULL;
+    PyObject *varlist = NULL;
+    PyObject *varlist_iter = NULL;
+    PyObject *varbind = NULL;
+    PyObject *varbinds = NULL;
     int varlist_len = 0;
     int varlist_ind;
-    netsnmp_session *ss;
-    netsnmp_pdu *pdu, *response;
-    netsnmp_variable_list *vars;
-    struct tree *tp;
+
+    struct session_capsule_ctx *session_ctx = NULL;
+    netsnmp_session *ss = NULL;
+    netsnmp_pdu *pdu = NULL;
+    netsnmp_pdu *response = NULL;
+    netsnmp_variable_list *vars = NULL;
+
+    struct tree *tp = NULL;
     int len;
     oid **oid_arr = NULL;
     int *oid_arr_len = NULL;
-    oid **oid_arr_broken_check = NULL;
-    int *oid_arr_broken_check_len = NULL;
+    char **initial_oid_str_arr = NULL;
+    char **oid_str_arr = NULL;
+    char **oid_idx_str_arr = NULL;
     int type;
     char type_str[MAX_TYPE_NAME_LEN];
     int status;
@@ -3186,8 +3327,6 @@ static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args)
     size_t str_buf_len = sizeof(str_buf);
     size_t out_len = 0;
     int buf_over = 0;
-    char *tag;
-    char *iid = NULL;
     int getlabel_flag = NO_FLAGS;
     int sprintval_flag = USE_BASIC;
     int old_format;
@@ -3197,11 +3336,14 @@ static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args)
     int err_num;
     char err_str[STR_BUF_SIZE];
     int notdone = 1;
-    char *tmpstr;
+    char *tmpstr = NULL;
     Py_ssize_t tmplen;
     int error = 0;
+    int nonrepeaters;
+    int maxrepetitions;
 
-    py_log_msg(ERROR, "netsnmp_bulkwalk: Starting");
+    py_log_msg(DEBUG, "netsnmp_bulkwalk: Starting");
+
     if (args)
     {
         if (!PyArg_ParseTuple(args, "OiiO", &session, &nonrepeaters,
@@ -3210,8 +3352,8 @@ static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args)
             goto done;
         }
 
-        py_log_msg(ERROR, "netsnmp_bulkwalk: nonreps:%d max_reps:%d",
-          nonrepeaters, maxrepetitions);
+        py_log_msg(DEBUG, "netsnmp_bulkwalk: nonreps (%d) max_reps (%d)",
+                   nonrepeaters, maxrepetitions);
 
         if (!varlist)
         {
@@ -3222,7 +3364,16 @@ static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args)
         {
             goto done;
         }
-        ss = (SnmpSession *)py_netsnmp_attr_void_ptr(session, "sess_ptr");
+
+        sess_ptr = PyObject_GetAttrString(session, "sess_ptr");
+        session_ctx = get_session_handle_from_capsule(sess_ptr);
+
+        if (!session_ctx)
+        {
+            goto done;
+        }
+
+        ss = session_ctx->handle;
 
         if (py_netsnmp_attr_string(session, "error_string", &tmpstr, &tmplen) < 0)
         {
@@ -3248,12 +3399,9 @@ static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args)
         {
             sprintval_flag = USE_SPRINT_VALUE;
         }
+
         best_guess = py_netsnmp_attr_long(session, "best_guess");
         retry_nosuch = py_netsnmp_attr_long(session, "retry_no_such");
-
-        pdu = snmp_pdu_create(SNMP_MSG_GETBULK);
-        pdu->non_repeaters = nonrepeaters;
-        pdu->max_repetitions = maxrepetitions;
 
         /* we need an initial count for memory allocation */
         varlist_iter = PyObject_GetIter(varlist);
@@ -3261,99 +3409,105 @@ static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args)
         while (varlist_iter && (varbind = PyIter_Next(varlist_iter)))
         {
             varlist_len++;
+            /*
+             * Valgrind displays "Invalid read of size 1" when Py_DECREF is in
+             * use. It appears that the data is already free'd when attempting
+             * to access it.
+             */
+            //Py_DECREF(varbind);
         }
         Py_DECREF(varlist_iter);
 
-        oid_arr_len              = calloc(varlist_len, sizeof(int));
-        oid_arr_broken_check_len = calloc(varlist_len, sizeof(int));
-
-        oid_arr                  = calloc(varlist_len, sizeof(oid *));
-        oid_arr_broken_check     = calloc(varlist_len, sizeof(oid *));
+        oid_arr_len = calloc(varlist_len, sizeof(int));
+        oid_arr = calloc(varlist_len, sizeof(oid *));
+        initial_oid_str_arr = calloc(varlist_len, sizeof(char *));
+        oid_str_arr = calloc(varlist_len, sizeof(char *));
+        oid_idx_str_arr = calloc(varlist_len, sizeof(char *));
 
         for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
         {
             oid_arr[varlist_ind] = calloc(MAX_OID_LEN, sizeof(oid));
-            oid_arr_broken_check[varlist_ind] = calloc(MAX_OID_LEN,
-                                                       sizeof(oid));
-
-            oid_arr_len[varlist_ind]              = MAX_OID_LEN;
-            oid_arr_broken_check_len[varlist_ind] = MAX_OID_LEN;
+            oid_arr_len[varlist_ind] = MAX_OID_LEN;
         }
 
-        /* get the initial starting oids */
-        varlist_iter = PyObject_GetIter(varlist);
+        /* get the initial oids */
+        py_log_msg(DEBUG, "netsnmp_bulkwalk: Getting initial oids");
         varlist_ind = 0;
+        varlist_iter = PyObject_GetIter(varlist);
         while (varlist_iter && (varbind = PyIter_Next(varlist_iter)))
         {
-            if (py_netsnmp_attr_string(varbind, "oid", &tag, NULL) >= 0 &&
-                py_netsnmp_attr_string(varbind, "oid_index", &iid, NULL) >= 0)
+            if (py_netsnmp_attr_string(varbind, "oid",
+                                       &oid_str_arr[varlist_ind],
+                                       NULL) >= 0 &&
+                py_netsnmp_attr_string(varbind, "oid_index",
+                                       &oid_idx_str_arr[varlist_ind],
+                                       NULL) >= 0
+            )
             {
-                tp = __tag2oid(tag, iid,
-                               oid_arr[varlist_ind], &oid_arr_len[varlist_ind],
-                               NULL, best_guess);
+
+                initial_oid_str_arr[varlist_ind] = oid_str_arr[varlist_ind];
+
+                py_log_msg(DEBUG,
+                           "netsnmp_bulkwalk: Initial oid(%s) oid_idx(%s)",
+                           oid_str_arr[varlist_ind],
+                           oid_idx_str_arr[varlist_ind]);
+
+                // Get oid array len
+                tp = __tag2oid(oid_str_arr[varlist_ind],
+                               oid_idx_str_arr[varlist_ind],
+                               oid_arr[varlist_ind],
+                               &oid_arr_len[varlist_ind], NULL, best_guess);
             }
             else
             {
                 oid_arr_len[varlist_ind] = 0;
             }
 
-            if (oid_arr_len[varlist_ind])
-            {
-                py_log_msg(ERROR, "netsnmp_bulkwalk: filling request: oid(%s) oid_idx(%s) oid_arr_len(%d) best_guess(%d)",
-                           tag, iid, oid_arr_len[varlist_ind], best_guess);
-
-                snmp_add_null_var(pdu, oid_arr[varlist_ind],
-                                  oid_arr_len[varlist_ind]);
-            }
-            else
+            if (!oid_arr_len[varlist_ind])
             {
                 PyErr_Format(EasySNMPUnknownObjectIDError,
                              "unknown object id (%s)",
-                             (tag ? tag : "<null>"));
+                             (oid_str_arr[varlist_ind] ? oid_str_arr[varlist_ind] : "<null>"));
                 error = 1;
-                snmp_free_pdu(pdu);
                 Py_DECREF(varbind);
                 goto done;
             }
-            /* release reference when done */
+
             Py_DECREF(varbind);
             varlist_ind++;
         }
 
-        if (varlist_iter)
-        {
-            Py_DECREF(varlist_iter);
-        }
+        Py_XDECREF(varlist_iter);
 
         if (PyErr_Occurred())
         {
             error = 1;
-            snmp_free_pdu(pdu);
             goto done;
         }
 
         /*
-        ** Set up for numeric or full OID's, if necessary.  Save the old
-        ** output format so that it can be restored when we finish -- this
-        ** is a library-wide global, and has to be set/restored for each
-        ** session.
-        */
+         * Set up for numeric or full OID's, if necessary.  Save the old
+         * output format so that it can be restored when we finish -- this
+         * is a library-wide global, and has to be set/restored for each
+         * session.
+         */
         old_format = netsnmp_ds_get_int(NETSNMP_DS_LIBRARY_ID,
                                         NETSNMP_DS_LIB_OID_OUTPUT_FORMAT);
 
         if (py_netsnmp_attr_long(session, "use_long_names"))
         {
             getlabel_flag |= USE_LONG_NAMES;
-
             netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
                                NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
                                NETSNMP_OID_OUTPUT_FULL);
         }
 
-        /* Setting use_numeric forces use_long_names on so check for
-           use_numeric after use_long_names (above) to make sure the final
-           outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
-           NETSNMP_OID_OUTPUT_NUMERIC */
+         /*
+          * Setting use_numeric forces use_long_names on so check for
+          * use_numeric after use_long_names (above) to make sure the final
+          * outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
+          * NETSNMP_OID_OUTPUT_NUMERIC
+          */
         if (py_netsnmp_attr_long(session, "use_numeric"))
         {
             getlabel_flag |= USE_LONG_NAMES;
@@ -3370,183 +3524,186 @@ static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args)
         if (PyErr_Occurred())
         {
             error = 1;
-            snmp_free_pdu(pdu);
             goto done;
         }
 
-        /* save the starting OID */
-        for (vars = pdu->variables, varlist_ind = 0;
-             vars != NULL;
-             vars = vars->next_variable, varlist_ind++)
-        {
-            oid_arr_broken_check[varlist_ind] =
-                calloc(MAX_OID_LEN, sizeof(oid));
-
-            oid_arr_broken_check_len[varlist_ind] = vars->name_length;
-            memcpy(oid_arr_broken_check[varlist_ind],
-                   vars->name, vars->name_length * sizeof(oid));
-            //py_log_msg(ERROR, "Saving starting OID: %s", oid_arr_broken_check[varlist_ind]);
-        }
-
+        py_log_msg(DEBUG, "netsnmp_bulkwalk: Starting bulk walk request");
         for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
         {
-          notdone = 1;
-          while (notdone) {
-              py_log_msg(ERROR, "netsnmp_bulkwalk: Sending pdu req");
-              status = __send_sync_pdu(ss, pdu, &response, retry_nosuch,
-                                       err_str, &err_num, &err_ind, NULL);
-              __py_netsnmp_update_session_errors(session, err_str, err_num,
-                                                 err_ind);
-              if (status != 0)
-              {
-                  error = 1;
-                  goto done;
-              }
+            pdu = snmp_pdu_create(SNMP_MSG_GETBULK);
+            pdu->non_repeaters = nonrepeaters;
+            pdu->max_repetitions = maxrepetitions;
+            snmp_add_null_var(pdu, oid_arr[varlist_ind], oid_arr_len[varlist_ind]);
 
-              if (!response || !response->variables ||
-                  status != STAT_SUCCESS ||
-                  response->errstat != SNMP_ERR_NOERROR)
-              {
-                  notdone = 0;
-              }
+            py_log_msg(DEBUG,
+                       "netsnmp_bulkwalk: filling request: oid(%s) "
+                       "oid_idx(%s) oid_arr_len(%d) best_guess(%d)",
+                       oid_str_arr[varlist_ind],
+                       oid_idx_str_arr[varlist_ind],
+                       oid_arr_len[varlist_ind],
+                       best_guess);
 
-              if(notdone)
-              {
-                  vars = (response ? response->variables : NULL);
-                  while (vars)
-                  {
-                      if ((vars->name_length < oid_arr_len[varlist_ind]) ||
-                          (memcmp(oid_arr[varlist_ind], vars->name,
-                                  oid_arr_len[varlist_ind] * sizeof(oid)) != 0))
-                      {
-                          py_log_msg(ERROR, "netsnmp_bulkwalk: encountered end condition (next subtree iteration out of scope)");
-                          notdone = 0;
-                          break;
-                      }
+            notdone = 1;
+            while (notdone)
+            {
+                py_log_msg(DEBUG, "netsnmp_bulkwalk: Sending pdu req");
+                status = __send_sync_pdu(ss, pdu, &response, retry_nosuch,
+                                         err_str, &err_num, &err_ind, NULL);
 
-                      if ((vars->type == SNMP_ENDOFMIBVIEW) ||
-                          (vars->type == SNMP_NOSUCHOBJECT) ||
-                          (vars->type == SNMP_NOSUCHINSTANCE))
-                      {
-                          py_log_msg(ERROR, "netsnmp_bulkwalk: encountered end condition (ENDOFMIBVIEW, NOSUCHOBJECT, NO SUCH INSTANCE)");
-                          notdone = 0;
-                          break;
-                      }
+                __py_netsnmp_update_session_errors(session, err_str, err_num,
+                                                   err_ind);
+                if (status != 0) {
+                    error = 1;
+                    goto done;
+                }
 
-                      if (snmp_oid_compare(vars->name, vars->name_length,
-                                           oid_arr_broken_check[varlist_ind],
-                                           oid_arr_broken_check_len[varlist_ind]) <= 0)
-                      {
-                          /* The agent responded with an illegal response
-                             as the returning OID was lexogragically less
-                             then or equal to the requested OID...
-                             We need to give up here because an infite
-                             loop will result otherwise.
+                if (!response ||
+                    !response->variables ||
+                    status != STAT_SUCCESS ||
+                    response->errstat != SNMP_ERR_NOERROR)
+                {
+                    notdone = 0;
+                }
 
-                             XXX: this really should be an option to
-                             continue like the -Cc option to the snmpwalk
-                             application.
-                          */
-                          notdone = 0;
-                          py_log_msg(ERROR, "netsnmp_bulkwalk: encountered oid_arr_broken_check condition");
-                          break;
-                      }
+                if (notdone)
+                {
+                    vars = (response ? response->variables : NULL);
+                    while (vars)
+                    {
 
-                      varbind = py_netsnmp_construct_varbind();
+                        if ((vars->name_length < oid_arr_len[varlist_ind]) ||
+                            (memcmp(oid_arr[varlist_ind], vars->name,
+                                    oid_arr_len[varlist_ind] * sizeof(oid)) != 0))
+                        {
+                            py_log_msg(DEBUG,
+                                       "netsnmp_bulkwalk: encountered end condition "
+                                       "(next subtree iteration out of scope)");
+                            notdone = 0;
+                            break;
+                        }
 
-                      if (PyObject_HasAttrString(varbind, "oid"))
-                      {
-                          str_buf[0] = '.';
-                          str_buf[1] = '\0';
-                          out_len = 0;
-                          tp = netsnmp_sprint_realloc_objid_tree(&str_bufp,
-                                                                 &str_buf_len,
-                                                                 &out_len, 0,
-                                                                 &buf_over,
-                                                                 vars->name,
-                                                                 vars->name_length);
-                          str_buf[sizeof(str_buf) - 1] = '\0';
+                        if ((vars->type == SNMP_ENDOFMIBVIEW) ||
+                            (vars->type == SNMP_NOSUCHOBJECT) ||
+                            (vars->type == SNMP_NOSUCHINSTANCE))
+                        {
+                            py_log_msg(DEBUG,
+                                      "netsnmp_bulkwalk: encountered end condition "
+                                      "(ENDOFMIBVIEW, NOSUCHOBJECT, NO SUCH "
+                                      "INSTANCE)");
+                            notdone = 0;
+                            break;
+                        }
 
-                          type = __translate_asn_type(vars->type);
+                        varbind = py_netsnmp_construct_varbind();
 
-                          if (__is_leaf(tp))
-                          {
-                              getlabel_flag &= ~NON_LEAF_NAME;
-                              py_log_msg(ERROR, "netsnmp_bulkwalk: is_leaf: %d", tp->type);
-                          }
-                          else
-                          {
-                              getlabel_flag |= NON_LEAF_NAME;
-                              py_log_msg(ERROR, "netsnmp_bulkwalk: !is_leaf: %d", tp->type);
-                          }
+                        if (PyObject_HasAttrString(varbind, "oid"))
+                        {
+                            str_buf[0] = '.';
+                            str_buf[1] = '\0';
+                            out_len = 0;
+                            tp = netsnmp_sprint_realloc_objid_tree(&str_bufp,
+                                                                   &str_buf_len,
+                                                                   &out_len, 0,
+                                                                   &buf_over,
+                                                                   vars->name,
+                                                                   vars->name_length);
+                            str_buf[sizeof(str_buf) - 1] = '\0';
 
-                          py_log_msg(ERROR, "netsnmp_bulkwalk: str_buf: %s", str_buf);
+                            type = __translate_asn_type(vars->type);
 
-                          __get_label_iid((char *) str_buf, &tag, &iid,
-                                          getlabel_flag);
+                            if (__is_leaf(tp))
+                            {
+                                getlabel_flag &= ~NON_LEAF_NAME;
+                                py_log_msg(DEBUG,
+                                           "netsnmp_bulkwalk: is_leaf: %d",
+                                           tp->type);
+                            }
+                            else
+                            {
+                                getlabel_flag |= NON_LEAF_NAME;
+                                py_log_msg(DEBUG,
+                                           "netsnmp_bulkwalk: !is_leaf: %d",
+                                           tp->type);
+                            }
 
-                          py_log_msg(ERROR,
-                                     "netsnmp_bulkwalk: filling response: %s:%s",
-                                     tag, iid);
+                            py_log_msg(DEBUG, "netsnmp_bulkwalk: str_buf: %s",
+                                       str_buf);
 
-                          py_netsnmp_attr_set_string(varbind, "oid", tag,
-                                                     STRLEN(tag));
-                          py_netsnmp_attr_set_string(varbind, "oid_index", iid,
-                                                     STRLEN(iid));
+                            py_netsnmp_attr_set_string(varbind, "root_oid",
+                                                       initial_oid_str_arr[varlist_ind],
+                                                       STRLEN(initial_oid_str_arr[varlist_ind]));
 
-                          __get_type_str(type, type_str, 1);
+                            __get_label_iid((char *)str_buf,
+                                            &oid_str_arr[varlist_ind],
+                                            &oid_idx_str_arr[varlist_ind],
+                                            getlabel_flag);
 
-                          py_netsnmp_attr_set_string(varbind, "snmp_type",
-                                                     type_str, strlen(type_str));
+                            py_log_msg(DEBUG,
+                                       "netsnmp_bulkwalk: filling response: %s:%s",
+                                       oid_str_arr[varlist_ind],
+                                       oid_idx_str_arr[varlist_ind]);
 
-                          len = __snprint_value((char *) str_buf,
-                                                sizeof(str_buf), vars, tp,
-                                                type, sprintval_flag);
-                          str_buf[len] = '\0';
+                            py_netsnmp_attr_set_string(varbind, "oid",
+                                                       oid_str_arr[varlist_ind],
+                                                       STRLEN(oid_str_arr[varlist_ind]));
 
-                          py_netsnmp_attr_set_string(varbind, "value",
-                                                     (char *) str_buf, len);
+                            py_netsnmp_attr_set_string(varbind, "oid_index",
+                                                       oid_idx_str_arr[varlist_ind],
+                                                       STRLEN(oid_idx_str_arr[varlist_ind]));
 
-                          /* push the varbind onto the return varbinds */
-                          PyList_Append(varbinds, varbind);
-                      }
-                      else
-                      {
-                          py_log_msg(ERROR, "netsnmp_bulkwalk: bad varbind (%d)",
-                                     varlist_ind);
-                      }
-                      Py_XDECREF(varbind);
+                            __get_type_str(type, type_str, 1);
 
-                      memcpy(oid_arr_broken_check[varlist_ind], vars->name,
-                             sizeof(oid) * vars->name_length);
-                      oid_arr_broken_check_len[varlist_ind] = vars->name_length;
+                            py_netsnmp_attr_set_string(varbind, "snmp_type",
+                                                       type_str,
+                                                       strlen(type_str));
 
-                      // Create next request if we've reached the end
-                      if(vars->next_variable == NULL) {
-                        pdu = snmp_pdu_create(SNMP_MSG_GETBULK);
-                        pdu->non_repeaters = nonrepeaters;
-                        pdu->max_repetitions = maxrepetitions;
-                        snmp_add_null_var(pdu, vars->name, vars->name_length);
-                      }
+                            len = __snprint_value((char *)str_buf,
+                                                  sizeof(str_buf), vars, tp,
+                                                  type, sprintval_flag);
+                            str_buf[len] = '\0';
 
-                      // Move on to next
-                      vars = vars->next_variable;
-                  }
-                  py_log_msg(ERROR, "netsnmp_bulkwalk: Finished reading all variables for req");
-              }
+                            py_netsnmp_attr_set_string(varbind, "value",
+                                                       (char *)str_buf, len);
 
-              if (response)
-              {
-                  snmp_free_pdu(response);
-              }
+                            /* push the varbind onto the return varbinds */
+                            PyList_Append(varbinds, varbind);
+                        }
+                        else
+                        {
+                            py_log_msg(DEBUG,
+                                       "netsnmp_bulkwalk: bad varbind (%d)",
+                                       varlist_ind);
+                        }
+                        Py_XDECREF(varbind);
+
+                        // Create next request if we've reached the end
+                        if (vars->next_variable == NULL) {
+                            pdu = snmp_pdu_create(SNMP_MSG_GETBULK);
+                            pdu->non_repeaters = nonrepeaters;
+                            pdu->max_repetitions = maxrepetitions;
+                            snmp_add_null_var(pdu, vars->name, vars->name_length);
+                        }
+
+                        // Move on to next
+                        vars = vars->next_variable;
+                    }
+                    py_log_msg(DEBUG,
+                               "netsnmp_bulkwalk: Finished reading all "
+                               "variables for req");
+                }
+
+                if (response)
+                {
+                    snmp_free_pdu(response);
+                }
             }
         }
+        py_log_msg(DEBUG, "netsnmp_bulkwalk: Ending bulk walk request");
 
         /* Reset the library's behavior for numeric/symbolic OID's. */
         netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
                            NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
                            old_format);
-
 
         if (PyErr_Occurred())
         {
@@ -3555,57 +3712,60 @@ static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args)
     }
 
 done:
-
+    py_log_msg(DEBUG, "netsnmp_bulkwalk: Starting cleanup");
     Py_XDECREF(varbinds);
+    Py_XDECREF(sess_ptr);
+    SAFE_FREE(initial_oid_str_arr);
     SAFE_FREE(oid_arr_len);
-    SAFE_FREE(oid_arr_broken_check_len);
+
     for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
     {
         SAFE_FREE(oid_arr[varlist_ind]);
-        SAFE_FREE(oid_arr_broken_check[varlist_ind]);
     }
+
     SAFE_FREE(oid_arr);
-    SAFE_FREE(oid_arr_broken_check);
+    SAFE_FREE(oid_str_arr);
+    SAFE_FREE(oid_idx_str_arr);
+    py_log_msg(DEBUG, "netsnmp_bulkwalk: End cleanup");
+
     if (error)
     {
         return NULL;
     }
-    else
-    {
-        return Py_None;
-    }
+    return Py_None;
 }
 
 static PyObject *netsnmp_set(PyObject *self, PyObject *args)
 {
     PyObject *session = NULL;
+    PyObject *sess_ptr = NULL;
     PyObject *varlist = NULL;
     PyObject *varbind = NULL;
     PyObject *ret = NULL;
-    netsnmp_session *ss;
-    netsnmp_pdu *pdu, *response;
-    struct tree *tp;
-    char *tag;
-    char *iid;
-    char *val;
+    struct session_capsule_ctx *session_ctx = NULL;
+    netsnmp_session *ss = NULL;
+    netsnmp_pdu *pdu = NULL;
+    netsnmp_pdu *response = NULL;
+    struct tree *tp = NULL;
+    char *tag = NULL;
+    char *iid = NULL;
+    char *val = NULL;
     char *type_str;
     int len;
-    oid *oid_arr;
+    oid *oid_arr = calloc(MAX_OID_LEN, sizeof(oid));
     int oid_arr_len = MAX_OID_LEN;
     int type;
     u_char tmp_val_str[STR_BUF_SIZE];
     int use_enums;
-    struct enum_list *ep;
+    struct enum_list *ep = NULL;
     int best_guess;
     int status;
     int err_ind;
     int err_num;
     char err_str[STR_BUF_SIZE];
-    char *tmpstr;
+    char *tmpstr = NULL;
     Py_ssize_t tmplen;
     int error = 0;
-
-    oid_arr = calloc(MAX_OID_LEN, sizeof(oid));
 
     if (oid_arr && args)
     {
@@ -3614,7 +3774,15 @@ static PyObject *netsnmp_set(PyObject *self, PyObject *args)
             goto done;
         }
 
-        ss = (SnmpSession *)py_netsnmp_attr_void_ptr(session, "sess_ptr");
+        sess_ptr = PyObject_GetAttrString(session, "sess_ptr");
+        session_ctx = get_session_handle_from_capsule(sess_ptr);
+
+        if (!session_ctx)
+        {
+            goto done;
+        }
+
+        ss = session_ctx->handle;
 
         /* PyObject_SetAttrString(); */
         if (py_netsnmp_attr_string(session, "error_string", &tmpstr, &tmplen) < 0)
@@ -3652,6 +3820,9 @@ static PyObject *netsnmp_set(PyObject *self, PyObject *args)
                                  (tag ? tag : "<null>"));
                     error = 1;
                     snmp_free_pdu(pdu);
+                    /* Py_XDECREF is called at the end; no need to DECREF here */
+                    // Py_DECREF(varbind);
+                    Py_DECREF(varlist_iter);
                     goto done;
                 }
 
@@ -3660,6 +3831,8 @@ static PyObject *netsnmp_set(PyObject *self, PyObject *args)
                     if (py_netsnmp_attr_string(varbind, "snmp_type", &type_str, NULL) < 0)
                     {
                         snmp_free_pdu(pdu);
+                        // Py_DECREF(varbind);
+                        Py_DECREF(varlist_iter);
                         goto done;
                     }
                     type = __translate_appl_type(type_str);
@@ -3670,6 +3843,8 @@ static PyObject *netsnmp_set(PyObject *self, PyObject *args)
                                         "the object");
                         error = 1;
                         snmp_free_pdu(pdu);
+                        // Py_DECREF(varbind);
+                        Py_DECREF(varlist_iter);
                         goto done;
                     }
                 }
@@ -3677,6 +3852,8 @@ static PyObject *netsnmp_set(PyObject *self, PyObject *args)
                 if (py_netsnmp_attr_string(varbind, "value", &val, &tmplen) < 0)
                 {
                     snmp_free_pdu(pdu);
+                    // Py_DECREF(varbind);
+                    Py_DECREF(varlist_iter);
                     goto done;
                 }
                 memset(tmp_val_str, 0, sizeof(tmp_val_str));
@@ -3745,17 +3922,14 @@ static PyObject *netsnmp_set(PyObject *self, PyObject *args)
     }
 
 done:
-
+    Py_XDECREF(sess_ptr);
     Py_XDECREF(varbind);
     SAFE_FREE(oid_arr);
     if (error)
     {
         return NULL;
     }
-    else
-    {
-        return (ret ? ret : Py_BuildValue(""));
-    }
+    return (ret ? ret : Py_BuildValue(""));
 }
 
 /**
@@ -3783,7 +3957,6 @@ static PyObject *py_get_logger(char *logger_name)
      *
      * However NullHandler doesn't come with python <2.6 and <3.1, so we need
      * to improvise by using an identical copy in easysnmp.compat.
-     *
      */
 
     null_handler = PyObject_CallMethod(easysnmp_compat_import, "NullHandler", NULL);
@@ -3890,12 +4063,6 @@ static PyMethodDef interface_methods[] =
             netsnmp_create_session_tunneled,
             METH_VARARGS,
             "create a tunneled netsnmp session over tls, dtls or ssh."
-        },
-        {
-            "delete_session",
-            netsnmp_delete_session,
-            METH_VARARGS,
-            "create a netsnmp session."
         },
         {
             "get",

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -2471,7 +2471,14 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
     netsnmp_session *ss;
     netsnmp_pdu *pdu, *response;
     netsnmp_pdu *newpdu;
-    netsnmp_variable_list *vars, *oldvars;
+    /*
+    Variable `oldvars` does not appear to fufill any immediate purpose and
+    causes segfaults in some cases, especially when running against OID '.1'
+    For legacy reasons, however, we will only leave it commented out, should
+    we find that it was only partially implemented or actually served a purpose
+    somewhere in the Net-SNMP library
+    */
+    netsnmp_variable_list *vars;//, *oldvars;
     struct tree *tp;
     int len;
     oid **oid_arr = NULL;
@@ -2710,11 +2717,11 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
                 newpdu = snmp_pdu_create(SNMP_MSG_GETNEXT);
 
                 for (vars = (response ? response->variables : NULL),
-                     varlist_ind = 0,
-                     oldvars = (pdu ? pdu->variables : NULL);
+                     varlist_ind = 0; //,
+                     //oldvars = (pdu ? pdu->variables : NULL);
                      vars && (varlist_ind < varlist_len);
-                     vars = vars->next_variable, varlist_ind++,
-                     oldvars = (oldvars ? oldvars->next_variable : NULL))
+                     vars = vars->next_variable, varlist_ind++)//,
+                     //oldvars = (oldvars ? oldvars->next_variable : NULL))
                 {
                     if ((vars->name_length < oid_arr_len[varlist_ind]) ||
                         (memcmp(oid_arr[varlist_ind], vars->name,
@@ -2946,8 +2953,8 @@ static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
 
             pdu = snmp_pdu_create(SNMP_MSG_GETBULK);
 
-            pdu->errstat = nonrepeaters;
-            pdu->errindex = maxrepetitions;
+            pdu->non_repeaters = nonrepeaters;
+            pdu->max_repetitions = maxrepetitions;
 
             varbinds_iter = PyObject_GetIter(varbinds);
 
@@ -3151,11 +3158,429 @@ done:
     }
 }
 
-static PyObject *netsnmp_set(PyObject *self, PyObject *args)
+static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args)
 {
+    int nonrepeaters;
+    int maxrepetitions;
     PyObject *session;
     PyObject *varlist;
+    PyObject *varlist_iter;
     PyObject *varbind;
+    PyObject *varbinds  = NULL;
+    int varlist_len = 0;
+    int varlist_ind;
+    netsnmp_session *ss;
+    netsnmp_pdu *pdu, *response;
+    netsnmp_variable_list *vars;
+    struct tree *tp;
+    int len;
+    oid **oid_arr = NULL;
+    int *oid_arr_len = NULL;
+    oid **oid_arr_broken_check = NULL;
+    int *oid_arr_broken_check_len = NULL;
+    int type;
+    char type_str[MAX_TYPE_NAME_LEN];
+    int status;
+    u_char str_buf[STR_BUF_SIZE];
+    u_char *str_bufp = str_buf;
+    size_t str_buf_len = sizeof(str_buf);
+    size_t out_len = 0;
+    int buf_over = 0;
+    char *tag;
+    char *iid = NULL;
+    int getlabel_flag = NO_FLAGS;
+    int sprintval_flag = USE_BASIC;
+    int old_format;
+    int best_guess;
+    int retry_nosuch;
+    int err_ind;
+    int err_num;
+    char err_str[STR_BUF_SIZE];
+    int notdone = 1;
+    char *tmpstr;
+    Py_ssize_t tmplen;
+    int error = 0;
+
+    py_log_msg(ERROR, "netsnmp_bulkwalk: Starting");
+    if (args)
+    {
+        if (!PyArg_ParseTuple(args, "OiiO", &session, &nonrepeaters,
+                              &maxrepetitions, &varlist))
+        {
+            goto done;
+        }
+
+        py_log_msg(ERROR, "netsnmp_bulkwalk: nonreps:%d max_reps:%d",
+          nonrepeaters, maxrepetitions);
+
+        if (!varlist)
+        {
+            goto done;
+        }
+
+        if ((varbinds = PyObject_GetAttrString(varlist, "varbinds")) == NULL)
+        {
+            goto done;
+        }
+        ss = (SnmpSession *)py_netsnmp_attr_void_ptr(session, "sess_ptr");
+
+        if (py_netsnmp_attr_string(session, "error_string", &tmpstr, &tmplen) < 0)
+        {
+            goto done;
+        }
+        memcpy(&err_str, tmpstr, tmplen);
+        err_num = py_netsnmp_attr_long(session, "error_number");
+        err_ind = py_netsnmp_attr_long(session, "error_index");
+
+        if (py_netsnmp_attr_long(session, "use_long_names"))
+        {
+            getlabel_flag |= USE_LONG_NAMES;
+        }
+        if (py_netsnmp_attr_long(session, "use_numeric"))
+        {
+            getlabel_flag |= USE_NUMERIC_OIDS;
+        }
+        if (py_netsnmp_attr_long(session, "use_enums"))
+        {
+            sprintval_flag = USE_ENUMS;
+        }
+        if (py_netsnmp_attr_long(session, "use_sprint_value"))
+        {
+            sprintval_flag = USE_SPRINT_VALUE;
+        }
+        best_guess = py_netsnmp_attr_long(session, "best_guess");
+        retry_nosuch = py_netsnmp_attr_long(session, "retry_no_such");
+
+        pdu = snmp_pdu_create(SNMP_MSG_GETBULK);
+        pdu->non_repeaters = nonrepeaters;
+        pdu->max_repetitions = maxrepetitions;
+
+        /* we need an initial count for memory allocation */
+        varlist_iter = PyObject_GetIter(varlist);
+        varlist_len = 0;
+        while (varlist_iter && (varbind = PyIter_Next(varlist_iter)))
+        {
+            varlist_len++;
+        }
+        Py_DECREF(varlist_iter);
+
+        oid_arr_len              = calloc(varlist_len, sizeof(int));
+        oid_arr_broken_check_len = calloc(varlist_len, sizeof(int));
+
+        oid_arr                  = calloc(varlist_len, sizeof(oid *));
+        oid_arr_broken_check     = calloc(varlist_len, sizeof(oid *));
+
+        for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
+        {
+            oid_arr[varlist_ind] = calloc(MAX_OID_LEN, sizeof(oid));
+            oid_arr_broken_check[varlist_ind] = calloc(MAX_OID_LEN,
+                                                       sizeof(oid));
+
+            oid_arr_len[varlist_ind]              = MAX_OID_LEN;
+            oid_arr_broken_check_len[varlist_ind] = MAX_OID_LEN;
+        }
+
+        /* get the initial starting oids */
+        varlist_iter = PyObject_GetIter(varlist);
+        varlist_ind = 0;
+        while (varlist_iter && (varbind = PyIter_Next(varlist_iter)))
+        {
+            if (py_netsnmp_attr_string(varbind, "oid", &tag, NULL) >= 0 &&
+                py_netsnmp_attr_string(varbind, "oid_index", &iid, NULL) >= 0)
+            {
+                tp = __tag2oid(tag, iid,
+                               oid_arr[varlist_ind], &oid_arr_len[varlist_ind],
+                               NULL, best_guess);
+            }
+            else
+            {
+                oid_arr_len[varlist_ind] = 0;
+            }
+
+            if (oid_arr_len[varlist_ind])
+            {
+                py_log_msg(ERROR, "netsnmp_bulkwalk: filling request: oid(%s) oid_idx(%s) oid_arr_len(%d) best_guess(%d)",
+                           tag, iid, oid_arr_len[varlist_ind], best_guess);
+
+                snmp_add_null_var(pdu, oid_arr[varlist_ind],
+                                  oid_arr_len[varlist_ind]);
+            }
+            else
+            {
+                PyErr_Format(EasySNMPUnknownObjectIDError,
+                             "unknown object id (%s)",
+                             (tag ? tag : "<null>"));
+                error = 1;
+                snmp_free_pdu(pdu);
+                Py_DECREF(varbind);
+                goto done;
+            }
+            /* release reference when done */
+            Py_DECREF(varbind);
+            varlist_ind++;
+        }
+
+        if (varlist_iter)
+        {
+            Py_DECREF(varlist_iter);
+        }
+
+        if (PyErr_Occurred())
+        {
+            error = 1;
+            snmp_free_pdu(pdu);
+            goto done;
+        }
+
+        /*
+        ** Set up for numeric or full OID's, if necessary.  Save the old
+        ** output format so that it can be restored when we finish -- this
+        ** is a library-wide global, and has to be set/restored for each
+        ** session.
+        */
+        old_format = netsnmp_ds_get_int(NETSNMP_DS_LIBRARY_ID,
+                                        NETSNMP_DS_LIB_OID_OUTPUT_FORMAT);
+
+        if (py_netsnmp_attr_long(session, "use_long_names"))
+        {
+            getlabel_flag |= USE_LONG_NAMES;
+
+            netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
+                               NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
+                               NETSNMP_OID_OUTPUT_FULL);
+        }
+
+        /* Setting use_numeric forces use_long_names on so check for
+           use_numeric after use_long_names (above) to make sure the final
+           outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
+           NETSNMP_OID_OUTPUT_NUMERIC */
+        if (py_netsnmp_attr_long(session, "use_numeric"))
+        {
+            getlabel_flag |= USE_LONG_NAMES;
+            getlabel_flag |= USE_NUMERIC_OIDS;
+
+            netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
+                               NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
+                               NETSNMP_OID_OUTPUT_NUMERIC);
+        }
+
+        /* delete the existing varbinds that we'll replace */
+        PySequence_DelSlice(varbinds, 0, PySequence_Length(varbinds));
+
+        if (PyErr_Occurred())
+        {
+            error = 1;
+            snmp_free_pdu(pdu);
+            goto done;
+        }
+
+        /* save the starting OID */
+        for (vars = pdu->variables, varlist_ind = 0;
+             vars != NULL;
+             vars = vars->next_variable, varlist_ind++)
+        {
+            oid_arr_broken_check[varlist_ind] =
+                calloc(MAX_OID_LEN, sizeof(oid));
+
+            oid_arr_broken_check_len[varlist_ind] = vars->name_length;
+            memcpy(oid_arr_broken_check[varlist_ind],
+                   vars->name, vars->name_length * sizeof(oid));
+            //py_log_msg(ERROR, "Saving starting OID: %s", oid_arr_broken_check[varlist_ind]);
+        }
+
+        for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
+        {
+          notdone = 1;
+          while (notdone) {
+              py_log_msg(ERROR, "netsnmp_bulkwalk: Sending pdu req");
+              status = __send_sync_pdu(ss, pdu, &response, retry_nosuch,
+                                       err_str, &err_num, &err_ind, NULL);
+              __py_netsnmp_update_session_errors(session, err_str, err_num,
+                                                 err_ind);
+              if (status != 0)
+              {
+                  error = 1;
+                  goto done;
+              }
+
+              if (!response || !response->variables ||
+                  status != STAT_SUCCESS ||
+                  response->errstat != SNMP_ERR_NOERROR)
+              {
+                  notdone = 0;
+              }
+
+              if(notdone)
+              {
+                  vars = (response ? response->variables : NULL);
+                  while (vars)
+                  {
+                      if ((vars->name_length < oid_arr_len[varlist_ind]) ||
+                          (memcmp(oid_arr[varlist_ind], vars->name,
+                                  oid_arr_len[varlist_ind] * sizeof(oid)) != 0))
+                      {
+                          py_log_msg(ERROR, "netsnmp_bulkwalk: encountered end condition (next subtree iteration out of scope)");
+                          notdone = 0;
+                          break;
+                      }
+
+                      if ((vars->type == SNMP_ENDOFMIBVIEW) ||
+                          (vars->type == SNMP_NOSUCHOBJECT) ||
+                          (vars->type == SNMP_NOSUCHINSTANCE))
+                      {
+                          py_log_msg(ERROR, "netsnmp_bulkwalk: encountered end condition (ENDOFMIBVIEW, NOSUCHOBJECT, NO SUCH INSTANCE)");
+                          notdone = 0;
+                          break;
+                      }
+
+                      if (snmp_oid_compare(vars->name, vars->name_length,
+                                           oid_arr_broken_check[varlist_ind],
+                                           oid_arr_broken_check_len[varlist_ind]) <= 0)
+                      {
+                          /* The agent responded with an illegal response
+                             as the returning OID was lexogragically less
+                             then or equal to the requested OID...
+                             We need to give up here because an infite
+                             loop will result otherwise.
+
+                             XXX: this really should be an option to
+                             continue like the -Cc option to the snmpwalk
+                             application.
+                          */
+                          notdone = 0;
+                          py_log_msg(ERROR, "netsnmp_bulkwalk: encountered oid_arr_broken_check condition");
+                          break;
+                      }
+
+                      varbind = py_netsnmp_construct_varbind();
+
+                      if (PyObject_HasAttrString(varbind, "oid"))
+                      {
+                          str_buf[0] = '.';
+                          str_buf[1] = '\0';
+                          out_len = 0;
+                          tp = netsnmp_sprint_realloc_objid_tree(&str_bufp,
+                                                                 &str_buf_len,
+                                                                 &out_len, 0,
+                                                                 &buf_over,
+                                                                 vars->name,
+                                                                 vars->name_length);
+                          str_buf[sizeof(str_buf) - 1] = '\0';
+
+                          type = __translate_asn_type(vars->type);
+
+                          if (__is_leaf(tp))
+                          {
+                              getlabel_flag &= ~NON_LEAF_NAME;
+                              py_log_msg(ERROR, "netsnmp_bulkwalk: is_leaf: %d", tp->type);
+                          }
+                          else
+                          {
+                              getlabel_flag |= NON_LEAF_NAME;
+                              py_log_msg(ERROR, "netsnmp_bulkwalk: !is_leaf: %d", tp->type);
+                          }
+
+                          py_log_msg(ERROR, "netsnmp_bulkwalk: str_buf: %s", str_buf);
+
+                          __get_label_iid((char *) str_buf, &tag, &iid,
+                                          getlabel_flag);
+
+                          py_log_msg(ERROR,
+                                     "netsnmp_bulkwalk: filling response: %s:%s",
+                                     tag, iid);
+
+                          py_netsnmp_attr_set_string(varbind, "oid", tag,
+                                                     STRLEN(tag));
+                          py_netsnmp_attr_set_string(varbind, "oid_index", iid,
+                                                     STRLEN(iid));
+
+                          __get_type_str(type, type_str, 1);
+
+                          py_netsnmp_attr_set_string(varbind, "snmp_type",
+                                                     type_str, strlen(type_str));
+
+                          len = __snprint_value((char *) str_buf,
+                                                sizeof(str_buf), vars, tp,
+                                                type, sprintval_flag);
+                          str_buf[len] = '\0';
+
+                          py_netsnmp_attr_set_string(varbind, "value",
+                                                     (char *) str_buf, len);
+
+                          /* push the varbind onto the return varbinds */
+                          PyList_Append(varbinds, varbind);
+                      }
+                      else
+                      {
+                          py_log_msg(ERROR, "netsnmp_bulkwalk: bad varbind (%d)",
+                                     varlist_ind);
+                      }
+                      Py_XDECREF(varbind);
+
+                      memcpy(oid_arr_broken_check[varlist_ind], vars->name,
+                             sizeof(oid) * vars->name_length);
+                      oid_arr_broken_check_len[varlist_ind] = vars->name_length;
+
+                      // Create next request if we've reached the end
+                      if(vars->next_variable == NULL) {
+                        pdu = snmp_pdu_create(SNMP_MSG_GETBULK);
+                        pdu->non_repeaters = nonrepeaters;
+                        pdu->max_repetitions = maxrepetitions;
+                        snmp_add_null_var(pdu, vars->name, vars->name_length);
+                      }
+
+                      // Move on to next
+                      vars = vars->next_variable;
+                  }
+                  py_log_msg(ERROR, "netsnmp_bulkwalk: Finished reading all variables for req");
+              }
+
+              if (response)
+              {
+                  snmp_free_pdu(response);
+              }
+            }
+        }
+
+        /* Reset the library's behavior for numeric/symbolic OID's. */
+        netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
+                           NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
+                           old_format);
+
+
+        if (PyErr_Occurred())
+        {
+            error = 1;
+        }
+    }
+
+done:
+
+    Py_XDECREF(varbinds);
+    SAFE_FREE(oid_arr_len);
+    SAFE_FREE(oid_arr_broken_check_len);
+    for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
+    {
+        SAFE_FREE(oid_arr[varlist_ind]);
+        SAFE_FREE(oid_arr_broken_check[varlist_ind]);
+    }
+    SAFE_FREE(oid_arr);
+    SAFE_FREE(oid_arr_broken_check);
+    if (error)
+    {
+        return NULL;
+    }
+    else
+    {
+        return Py_None;
+    }
+}
+
+static PyObject *netsnmp_set(PyObject *self, PyObject *args)
+{
+    PyObject *session = NULL;
+    PyObject *varlist = NULL;
+    PyObject *varbind = NULL;
     PyObject *ret = NULL;
     netsnmp_session *ss;
     netsnmp_pdu *pdu, *response;
@@ -3501,6 +3926,12 @@ static PyMethodDef interface_methods[] =
             netsnmp_walk,
             METH_VARARGS,
             "perform an SNMP WALK operation."
+        },
+        {
+            "bulkwalk",
+            netsnmp_bulkwalk,
+            METH_VARARGS,
+            "perform an SNMP BULKWALK operation."
         },
         {
             NULL,

--- a/easysnmp/session.py
+++ b/easysnmp/session.py
@@ -503,7 +503,3 @@ class Session(object):
 
         # Return a list of variables
         return varlist
-
-    def __del__(self):
-        """Deletes the session and frees up memory."""
-        return interface.delete_session(self)

--- a/easysnmp/session.py
+++ b/easysnmp/session.py
@@ -410,7 +410,7 @@ class Session(object):
         # Return a list or single item depending on what was passed in
         return list(varlist) if is_list else varlist[0]
 
-    def get_bulk(self, oids, non_repeaters, max_repetitions):
+    def get_bulk(self, oids, non_repeaters=0, max_repetitions=10):
         """
         Performs a bulk SNMP GET operation using the prepared session to
         retrieve multiple pieces of information in a single packet.
@@ -472,6 +472,37 @@ class Session(object):
 
         # Return a list of variables
         return list(varlist)
+
+    def bulkwalk(self, oids='.1.3.6.1.2.1', non_repeaters=0,
+                 max_repetitions=10):
+        """
+        Uses SNMP GETBULK operation using the prepared session to
+        automatically retrieve multiple pieces of information in an OID
+        :param oids: you may pass in a single item (multiple values currently
+                     experimental) which may be a string representing the
+                     entire OID (e.g. 'sysDescr.0') or may be a tuple
+                     containing the name as its first item and index as its
+                     second (e.g. ('sysDescr', 0))
+        :return: a list of SNMPVariable objects containing the values that
+                 were retrieved via SNMP
+        """
+
+        if self.version == 1:
+            raise EasySNMPError(
+                "BULKWALK is not available for SNMP version 1")
+
+        # Build our variable bindings for the C interface
+        varlist, _ = build_varlist(oids)
+
+        # Perform the SNMP walk using GETNEXT operations
+        interface.bulkwalk(self, non_repeaters, max_repetitions, varlist)
+
+        # Validate the variable list returned
+        if self.abort_on_nonexistent:
+            validate_results(varlist)
+
+        # Return a list of variables
+        return varlist
 
     def __del__(self):
         """Deletes the session and frees up memory."""

--- a/easysnmp/simple_bitarray.h
+++ b/easysnmp/simple_bitarray.h
@@ -3,41 +3,42 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <limits.h>
 #include <string.h>
 
 #if (__STDC_VERSION__ < 199901L)
 #define inline
 #endif
 
-typedef unsigned int bitarray_word;
+/*
+ * No weird architectures; we expect the following:
+ *   - a byte to be 8 bits (i.e. CHAR_BIT == 8)
+ *   - integral types do not have padding or reserved bits
+ *     e.g. if sizeof(unsigned int) == 4 then UINT_MAX == 4294967295
+ */
+typedef unsigned int bitarray;
 
 /*
- * this is not guaranteed to be portable since an integral type size
- * doesn't necessarily define the range
+ * This is not guaranteed to be portable since an integral type size
+ * dosn't necessarily define the range. See warning above about
+ * "no weird architectures."
  */
-#define BITARRAY_LIMB_BITS (sizeof(bitarray_word) * CHAR_BIT)
+#define BITARRAY_LIMB_BITS (sizeof(bitarray) * CHAR_BIT)
 
 /* macro to find the number of limbs to store num-bits */
 #define BITARRAY_NUM_BITS_TO_LIMBS(num_bits) \
     (((num_bits) + BITARRAY_LIMB_BITS - 1) / BITARRAY_LIMB_BITS)
 
+/* macro to find the number of limbs to store num-bits */
+#define BITARRAY_NUM_BITS_TO_BUF_SIZE(num_bits) \
+    ((BITARRAY_NUM_BITS_TO_LIMBS(num_bits) + 1) * sizeof(bitarray))
+
 /* fetch the limb containing bit position n */
-#define BITARRAY_LIMB(bitarray, n_bit) \
-    ((bitarray)[1 + ((n_bit) / BITARRAY_LIMB_BITS)].limb)
+#define BITARRAY_LIMB(bitarray, nbit) \
+    ((bitarray)[1 + ((nbit) / BITARRAY_LIMB_BITS)])
 
 /* build mask to select bit in limb */
-#define BITARRAY_LIMBBIT(n_bit) \
-    ((1UL << ((n_bit) % BITARRAY_LIMB_BITS)))
-
-/*
- * we use a struct to give a name;
- * when used, we reserve bitarray[0] for storing the number of bits.
- */
-typedef struct
-{
-    bitarray_word limb;
-} bitarray;
+#define BITARRAY_LIMBBIT(nbit) \
+    ((1UL << ((nbit) % BITARRAY_LIMB_BITS)))
 
 /*
  * To declare a bitarray with automatic storage:
@@ -46,119 +47,213 @@ typedef struct
  * }
  */
 #define BITARRAY_DECLARE(name, nbits) \
-    bitarray (name)[1 + BITARRAY_NUM_BITS_TO_LIMBS((nbits))] = { { nbits } }
+    bitarray (name)[1 + BITARRAY_NUM_BITS_TO_LIMBS((nbits))] = { nbits }
 
-static inline size_t bitarray_num_limbs(bitarray *bitarray)
+static inline size_t bitarray_num_limbs(bitarray *ba)
 {
-    return BITARRAY_NUM_BITS_TO_LIMBS(bitarray[0].limb);
+    return BITARRAY_NUM_BITS_TO_LIMBS(ba[0]);
 }
 
-static inline size_t bitarray_num_bits(bitarray *bitarray)
+static inline size_t bitarray_num_bits(bitarray *ba)
 {
-    return bitarray[0].limb;
+    return ba[0];
 }
 
-static inline void bitarray_set_bit(bitarray *bitarray, bitarray_word n)
+static inline void bitarray_set_bit(bitarray *ba, size_t n)
 {
-    BITARRAY_LIMB(bitarray, n) |= BITARRAY_LIMBBIT(n);
+    BITARRAY_LIMB(ba, n) |= BITARRAY_LIMBBIT(n);
 }
 
-static inline void bitarray_clear_bit(bitarray *bitarray, bitarray_word n)
+static inline void bitarray_clear_bit(bitarray *ba, size_t n)
 {
-    BITARRAY_LIMB(bitarray, n) &= ~BITARRAY_LIMBBIT(n);
+    BITARRAY_LIMB(ba, n) &= ~BITARRAY_LIMBBIT(n);
 }
 
-static inline void bitarray_change_bit(bitarray *bitarray, bitarray_word n)
+static inline void bitarray_change_bit(bitarray *ba, size_t n)
 {
-    BITARRAY_LIMB(bitarray, n) ^= BITARRAY_LIMBBIT(n);
+    BITARRAY_LIMB(ba, n) ^= BITARRAY_LIMBBIT(n);
 }
 
-static inline int bitarray_test_bit(const bitarray *bitarray, bitarray_word n)
+static inline int bitarray_test_bit(const bitarray *ba, size_t n)
 {
-    return !!(BITARRAY_LIMB(bitarray, n) & BITARRAY_LIMBBIT(n));
+    return !!(BITARRAY_LIMB(ba, n) & BITARRAY_LIMBBIT(n));
 }
 
-static inline void bitarray_zero(bitarray *bitarray)
+static inline void bitarray_zero(bitarray *ba)
 {
-    memset(&bitarray[1], 0, bitarray_num_limbs(bitarray));
+    size_t nbytes = sizeof(bitarray) * bitarray_num_limbs(ba);
+    memset(&ba[1], 0, nbytes);
 }
+
+/* clear bits at position 0 to (nbits-1) */
+static inline void bitarray_clear_bits(bitarray *ba, size_t nbits)
+{
+    if (ba[0] >= nbits)
+    {
+        /* clear the entire bitarray */
+        bitarray_zero(ba);
+    }
+    else
+    {
+        size_t nbytes;
+
+        /*
+         * cases:
+         *   - (1) nbits align on byte boundary
+         *   - (2) nbits does not align on byte boundary,
+         *         manually clear remaining bits
+         */
+        if (nbits % CHAR_BIT == 0)
+        {
+            nbytes = nbits * CHAR_BIT;
+        }
+        else
+        {
+            size_t remaining_bits = nbits % CHAR_BIT;
+            size_t i;
+
+            /* clear bits in the partial byte first */
+            for (i = nbits; i > (nbits - remaining_bits); i--)
+            {
+                bitarray_clear_bit(ba, i - 1);
+            }
+        }
+
+        memset(&ba[1], 0, nbytes);
+    }
+}
+
 
 /*
  * Allocation functions
  */
-static inline bitarray *bitarray_alloc(unsigned long nbits)
+static inline bitarray *bitarray_alloc(size_t nbits)
 {
         bitarray *ba = NULL;
 
-        size_t n_limbs = 1 + BITARRAY_NUM_BITS_TO_LIMBS(nbits);
+        size_t nlimbs = 1 + BITARRAY_NUM_BITS_TO_LIMBS(nbits);
 
-	ba = malloc(sizeof(bitarray) * n_limbs);
+        ba = malloc(sizeof(bitarray) * nlimbs);
         if (ba)
         {
-            ba[0].limb = nbits;
+            ba[0] = nbits;
         }
 
         return ba;
 }
 
-static inline bitarray *bitarray_calloc(unsigned long nbits)
+static inline bitarray *bitarray_calloc(size_t nbits)
 {
         bitarray *ba = NULL;
 
-        size_t n_limbs = 1 + BITARRAY_NUM_BITS_TO_LIMBS(nbits);
+        size_t nlimbs = 1 + BITARRAY_NUM_BITS_TO_LIMBS(nbits);
 
-	ba = calloc(sizeof(bitarray), n_limbs);
+        ba = calloc(sizeof(bitarray), nlimbs);
         if (ba)
         {
-            ba[0].limb = nbits;
+            ba[0] = nbits;
         }
 
-	return ba;
+        return ba;
 }
 
-static inline void bitarray_free(bitarray *bitarray)
+static inline void bitarray_free(bitarray *ba)
 {
-    if (bitarray)
+    if (ba)
     {
-        free(bitarray);
+        free(ba);
     }
 }
 
-static inline void bitarray_buf_init(void *buf, size_t buf_size)
+/*
+ * Take in a raw buffer and corresponding size and return a pointer to
+ * a newly initialised bitarray struct.
+ *
+ * buf_size is required to be minimum 2*sizeof(bitarray) in size.
+ *
+ * e.g.
+ *     unsigned char p[1024]; // bitarray will be slightly <8192 bits.
+ *     bitarray *ba = bitarray_buf_init(p, sizeof(p));
+ */
+static inline bitarray *bitarray_buf_init(void *buf, size_t buf_size)
 {
-        bitarray *ba = buf;
+    bitarray *ba = buf;
+    size_t nlimbs;
+    size_t nbits;
 
-        size_t nbits = (buf_size - sizeof(bitarray_word)) * CHAR_BIT;
+    if (!ba)
+    {
+        return NULL;
+    }
 
-        ba[0].limb = nbits;
+    /* the buf needs to have the size of at least 1 limb */
+    if (buf_size < sizeof(bitarray))
+    {
+        return NULL;
+    }
+
+    /*
+     * using the free available space (after allocating the initial limb)
+     * to determine how many limbs are available.
+     */
+    nlimbs = (buf_size - sizeof(bitarray)) / sizeof(bitarray);
+
+    if (nlimbs < 1)
+    {
+        nbits = 0;
+    }
+    else
+    {
+        nbits = nlimbs * sizeof(bitarray) * CHAR_BIT;
+    }
+
+    /* reserve a limb for storing number of bits */
+    ba[0] = nbits;
+    bitarray_zero(ba);
+
+    return (ba);
 }
 
-static inline void bitarray_print_base16(bitarray *bitarray)
+static inline void bitarray_print_base16(bitarray *ba)
 {
-    bitarray_word i;
-    size_t num_limbs = bitarray_num_limbs(bitarray);
+    bitarray i;
+    size_t num_limbs = bitarray_num_limbs(ba);
 
-    printf("sizeof(limb)=%lu\n", sizeof(bitarray[0].limb));
-    printf("num_limbs=%lu\n", num_limbs);
+    printf("DEBUG numbits=%lu\n", (unsigned long) ba[0]);
+    printf("DEBUG sizeof(limb)=%lu\n", sizeof(ba[0]));
+    printf("DEBUG num_limbs=%lu\n", num_limbs);
     for (i = 0; i <= num_limbs; i++)
     {
-            unsigned char c;
-            unsigned int j;
-            size_t limb_size = sizeof(bitarray_word);
+        unsigned char c;
+        unsigned int j;
+        size_t limb_size = sizeof(ba);
 
-            for (j = 0; j < limb_size; j++)
-            {
-                /* mask the byte we want to print in hex */
-                unsigned long mask = (0xFFUL) << (j * CHAR_BIT);
-                c = (unsigned char) ((bitarray[i].limb & mask) >> (j * CHAR_BIT));
-                printf("%02x", c);
-            }
-
-            printf(" ");
+        for (j = 0; j < limb_size; j++)
+        {
+            /* mask the byte we want to print in hex */
+            unsigned long mask = (0xFFUL) << (j * CHAR_BIT);
+            c = (unsigned char) ((ba[i] & mask) >> (j * CHAR_BIT));
+            printf("%02x", c);
         }
+
+        printf(" ");
+    }
 
     printf("\n");
 }
 
+
+/* ignore unused function warnings */
+static void wno_unused_function_simple_bitarray_h(void)
+{
+    (void) bitarray_num_bits(NULL);
+    (void) bitarray_change_bit(NULL, 0);
+    (void) bitarray_clear_bit(NULL, 0);
+    (void) bitarray_clear_bits(NULL, 0);
+    (void) bitarray_alloc(0);
+    (void) bitarray_calloc(0);
+    (void) bitarray_free(NULL);
+    return;
+}
 
 #endif

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,18 @@ else:
     libdirs = [flag[2:] for flag in shlex.split(netsnmp_libs) if flag.startswith('-L')]  # noqa
     incdirs = []
 
+    if sys.platform == 'darwin': # OS X
+        brew = os.popen('brew info net-snmp').read()
+        if not 'command not found' in brew and not 'error' in brew:
+            # /usr/local/opt is the default brew `opt` prefix, however the user may have installed it elsewhere
+            # The `brew info <pkg>` includes an apostrophe, which breaks shlex. We'll simply replace it
+            libdirs = [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-L')]    # noqa
+            incdirs = [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-I')]    # noqa
+            # The homebrew version also depends on the Openssl keg
+            brew = os.popen('brew info openssl').read()
+            libdirs += [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-L')]    # noqa
+            incdirs += [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-I')]    # noqa
+
 
 # Setup the py.test class for use with the test command
 class PyTest(TestCommand):

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from setuptools import setup, Extension
 from setuptools.command.test import test as TestCommand
 
 # Determine if a base directory has been provided with the --basedir option
+basedir = None
 in_tree = False
 # Add compiler flags if debug is set
 compile_args = ['-Wno-unused-function']
@@ -39,17 +40,18 @@ else:
     libdirs = [flag[2:] for flag in shlex.split(netsnmp_libs) if flag.startswith('-L')]  # noqa
     incdirs = []
 
-    if sys.platform == 'darwin': # OS X
+    if sys.platform == 'darwin':  # OS X
         brew = os.popen('brew info net-snmp').read()
-        if not 'command not found' in brew and not 'error' in brew:
-            # /usr/local/opt is the default brew `opt` prefix, however the user may have installed it elsewhere
-            # The `brew info <pkg>` includes an apostrophe, which breaks shlex. We'll simply replace it
-            libdirs = [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-L')]    # noqa
-            incdirs = [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-I')]    # noqa
+        if 'command not found' not in brew and 'error' not in brew:
+            # /usr/local/opt is the default brew `opt` prefix, however the user
+            # may have installed it elsewhere. The `brew info <pkg>` includes
+            # an apostrophe, which breaks shlex. We'll simply replace it
+            libdirs = [flag[2:] for flag in shlex.split(brew.replace('\'', '')) if flag.startswith('-L')]    # noqa
+            incdirs = [flag[2:] for flag in shlex.split(brew.replace('\'', '')) if flag.startswith('-I')]    # noqa
             # The homebrew version also depends on the Openssl keg
             brew = os.popen('brew info openssl').read()
-            libdirs += [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-L')]    # noqa
-            incdirs += [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-I')]    # noqa
+            libdirs += [flag[2:] for flag in shlex.split(brew.replace('\'', '')) if flag.startswith('-L')]    # noqa
+            incdirs += [flag[2:] for flag in shlex.split(brew.replace('\'', '')) if flag.startswith('-I')]    # noqa
 
 
 # Setup the py.test class for use with the test command

--- a/tests/test_easy.py
+++ b/tests/test_easy.py
@@ -5,7 +5,7 @@ import platform
 import pytest
 from easysnmp.easy import (
     snmp_get, snmp_set, snmp_set_multiple, snmp_get_next, snmp_get_bulk,
-    snmp_walk
+    snmp_walk, snmp_bulkwalk
 )
 from easysnmp.exceptions import (
     EasySNMPError, EasySNMPUnknownObjectIDError, EasySNMPNoSuchObjectError,
@@ -498,6 +498,39 @@ def test_snmp_walk_res(sess_args):
     assert res[5].oid_index == '0'
     assert res[5].value == 'my original location'
     assert res[5].snmp_type == 'OCTETSTR'
+
+
+@pytest.mark.parametrize(
+    'sess_args', [sess_v1_args(), sess_v2_args(), sess_v3_args()]
+)
+def test_snmp_bulkwalk_res(sess_args):
+    if sess_args['version'] == 1:
+        with pytest.raises(EasySNMPError):
+            snmp_bulkwalk('system', **sess_args)
+    else:
+        res = snmp_bulkwalk('system', **sess_args)
+
+        assert len(res) >= 7
+
+        assert res[0].oid == 'sysDescr'
+        assert res[0].oid_index == '0'
+        assert platform.version() in res[0].value
+        assert res[0].snmp_type == 'OCTETSTR'
+
+        assert res[3].oid == 'sysContact'
+        assert res[3].oid_index == '0'
+        assert res[3].value == 'G. S. Marzot <gmarzot@marzot.net>'
+        assert res[3].snmp_type == 'OCTETSTR'
+
+        assert res[4].oid == 'sysName'
+        assert res[4].oid_index == '0'
+        assert res[4].value == platform.node()
+        assert res[4].snmp_type == 'OCTETSTR'
+
+        assert res[5].oid == 'sysLocation'
+        assert res[5].oid_index == '0'
+        assert res[5].value == 'my original location'
+        assert res[5].snmp_type == 'OCTETSTR'
 
 
 @pytest.mark.parametrize(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -335,6 +335,37 @@ def test_session_walk(sess):
 
 
 @pytest.mark.parametrize('sess', [sess_v1(), sess_v2(), sess_v3()])
+def test_session_bulkwalk(sess):
+    if sess.version == 1:
+        with pytest.raises(EasySNMPError):
+            sess.bulkwalk('system')
+    else:
+        res = sess.walk('system')
+
+        assert len(res) >= 7
+
+        assert res[0].oid == 'sysDescr'
+        assert res[0].oid_index == '0'
+        assert platform.version() in res[0].value
+        assert res[0].snmp_type == 'OCTETSTR'
+
+        assert res[3].oid == 'sysContact'
+        assert res[3].oid_index == '0'
+        assert res[3].value == 'G. S. Marzot <gmarzot@marzot.net>'
+        assert res[3].snmp_type == 'OCTETSTR'
+
+        assert res[4].oid == 'sysName'
+        assert res[4].oid_index == '0'
+        assert res[4].value == platform.node()
+        assert res[4].snmp_type == 'OCTETSTR'
+
+        assert res[5].oid == 'sysLocation'
+        assert res[5].oid_index == '0'
+        assert res[5].value == 'my original location'
+        assert res[5].snmp_type == 'OCTETSTR'
+
+
+@pytest.mark.parametrize('sess', [sess_v1(), sess_v2(), sess_v3()])
 def test_session_walk_all(sess):
     # TODO: Determine why walking iso doesn't work for SNMP v1
     if sess.version == 1:


### PR DESCRIPTION
## Changelog
- Fixed an error where Net-SNMP is installed via Homebrew (5.7.x) but GCC
  links to system-default libraries (5.6.x)
- Implemented `bulkwalk` and added tests

_Note: this is a merge of #43 and #44 onto my main branch, having rebased to fgimian/master with recent documentation changes_
## Benchmarks

`Bulkwalk` has been benchmarked against `walk` and performs exceptionally well, at least with v2(c). I have not yet been able to run benchmarks for v3 but can do so if desired.

The following tests were performed locally on a Cisco C3750 running IOS C3750-IPBASEK9-M, Version 12.2(55)SE1, with SNMPv2. Each were given the following args:
- Retries - 1
- Timeout - 5 seconds
- OID - `.1`

|  | Net-SNMP `snmpbulkwalk` | Easysnmp `session.bulkwalk` | Net-SNMP `snmpwalk` | Easysnmp `session.walk` |
| --- | --- | --- | --- | --- |
| Time elapsed | 1m 21.258s | 1m 21.474s | 2m 14.405s | 2m 14.594s |
| OIDs returned | 33866 | 31788 - 31998 | 33864 | 31788 - 31998 |

---
### Notes

Both of Easysnmp's functions appear to be missing ~2,000 OID values in comparison to those found from Net-SNMP's and are inconsistent between test. The quantity of OIDs returned (the size of the list) differs by less than 5 each time the script is run, which may mean that this is caused when loading MIBs at runtime. It should be noted that this is also seen in the library prior to any changes made in this commit. I will be investigating this in the future to see why it is happening. Perhaps it's related to the same reason that `walk` cannot be passed `'.'` as the OID argument.

Memory leaks were also tested between both `bulkwalk` and `walk`. Prior to the removal of `oldvars` in the interface.c file, `walk` was reported to have "possibly lost" ~1MB of memory during this test by Valgrind. However, `walk` would encounter a segfault irregularly and a gdb session pointed towards this variable. It did not appear to actually be used by any significant part of the function; removing it does not reveal any impact on data returned. After removing it, Valgrind only reports a loss of ~505KB, only ~4KB more than `bulkwalk`. I am not sure if this variable actually does anything to move the function forward, so I have commented it out for now.

On the subject of memory leaks, measurements of "free memory" by `top` for both `walk` and `bulkwalk` indicate that memory _seems_ to be released properly back to the system. The values Valgrind reports as various categories of "lost memory" do not appear completely accurate and may just be due to Python not yet having completed a garbage collect when the script completes. `heapy` reports less than 540 bytes in use after deleting each `session` object,  however `heapy` seems to be limited in scope to only the Python instance and not the actual system. I have not tried `smem` as I did in #21 but I can run tests if desired.

And do forgive my edits on the docstrings: I was just trying to get the tests to pass :smile: 
